### PR TITLE
Fix/allow simultaneous metric links

### DIFF
--- a/catalog/povmap-philippines.yml
+++ b/catalog/povmap-philippines.yml
@@ -15,22 +15,29 @@ evaluation-metrics:
   - metric:
       metric-type: rsquared
       value: 0.59
-  - link:
-      description: 'Additional evaluation metrics discussion'
+    link:
+      description: 'How we computed the Rsquared for the Predicted Wealth Index'
       url: https://thinkingmachines.github.io/unicef-ai4d-poverty-mapping/notebooks/2023-01-17-initial-model-ph-mm-ph-kh/model_ph.html#evaluate-model-training-using-cross-validation
+  - metric:
+      metric-type: F1-Score
+      value: 0.49
+    link:
+      description: 'Additional evaluation metrics discussion on the F1 Score for the split quantiles'
+      url: https://thinkingmachines.github.io/unicef-ai4d-poverty-mapping/notebooks/2023-01-17-initial-model-ph-mm-ph-kh/model_ph.html#evaluate-model-training-using-cross-validation
+
 links:
-  - url: https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/model_ph_rollout.pkl
+  - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/model_ph_rollout.pkl
     description: 'Philippines Poverty Mapping Model Weights (.pkl). See related notebooks for usage'
     type: model-weights
-  - url: https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/rollout_output_ph.geojson
+  - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/rollout_output_ph.geojson
     description: 'Country wide rollout (inference) of the Poverty Mapping Model on Philippines using 2.4km grids (bingtile quadkey level 14)'
     type: 'dataset-geojson'
-  - url: https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-02-ph_final_model_rollout.ipynb
+  - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-02-ph_final_model_rollout.ipynb
     description: 'Philippines Model Rollout Part 3 (Feature Engineering and Model Prediction on Rollout Grids)'
     type: 'code-notebook'
-  - url: https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023_02-21-ph_final_model_training.ipynb
+  - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023_02-21-ph_final_model_training.ipynb
     description: 'Philippines Model Rollout Part 1 (Training Final Single-country Model)'
     type: 'code-notebook'
-  - url: https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-01-ph_generate_populated_grids.ipynb
+  - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-01-ph_generate_populated_grids.ipynb
     description: 'Philippines Model Rollout Part 2 (Generate Roll-out Grids)'
     type: 'code-notebook'

--- a/catalog/povmap-timor-leste-rollout-dataset.yml
+++ b/catalog/povmap-timor-leste-rollout-dataset.yml
@@ -12,20 +12,20 @@ tags:
 country-region: timor-leste
 year-period: 2016
 links:
-  - url: https://raw.githubusercontent.com/thinkingmachines/unicef-ai4d-poverty-mapping/main/notebooks/2023-02-21-single-country-rollouts/rollout_output_tl.geojson
+  - url: https://raw.githubusercontent.com/butchtm/unicef-ai4d-poverty-mapping/main/notebooks/2023-02-21-single-country-rollouts/rollout_output_tl.geojson
     description: 'Country wide rollout (inference) of the Poverty Mapping Model on Timor Leste using 2.4km grids (bingtile quadkey level 14) as geojson'
     type: 'dataset-raw-geojson'
   - url: https://raw.githubusercontent.com/butchtm/unicef-ai4d-poverty-mapping/main/notebooks/2023-02-21-single-country-rollouts/rollout_output_tl.csv
     description: 'Country wide rollout (inference) of the Poverty Mapping Model on Timor Leste using 2.4km grids (bingtile quadkey level 14) as CSV'
     type: 'dataset-raw-csv'
 
-  - url: https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-02-tl_final_model_rollout.ipynb
+  - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-02-tl_final_model_rollout.ipynb
     description: 'Timor Leste Model Rollout Part 3 (Feature Engineering and Model Prediction on Rollout Grids)'
     type: 'code-notebook'
-  - url: https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023_02-21-tl_final_model_training.ipynb
+  - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023_02-21-tl_final_model_training.ipynb
     description: 'Timor Leste Model Rollout Part 1 (Training Final Single-country Model)'
     type: 'code-notebook'
-  - url: https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-01-tl_generate_populated_grids.ipynb
+  - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-01-tl_generate_populated_grids.ipynb
     description: 'Timor Leste Model Rollout Part 2 (Generate Roll-out Grids)'
     type: 'code-notebook'
 data-columns:

--- a/catalog/povmap-timor-leste.yml
+++ b/catalog/povmap-timor-leste.yml
@@ -19,22 +19,22 @@ evaluation-metrics:
       description: 'Additional evaluation metrics discussion'
       url: https://thinkingmachines.github.io/unicef-ai4d-poverty-mapping/notebooks/2023-01-17-initial-model-ph-mm-tl-kh/model_tl.html#evaluate-model-training-using-cross-validation
 links:
-  - url: https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/model_tl_rollout.pkl
+  - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/model_tl_rollout.pkl
     description: 'Timor Leste Poverty Mapping Model Weights (.pkl). See related notebooks for usage'
     type: model-weights
-  - url: https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/rollout_output_tl.geojson
+  - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/rollout_output_tl.geojson
     description: 'Country wide rollout (inference) of the Poverty Mapping Model on Timor Leste using 2.4km grids (bingtile quadkey level 14) as geojson'
     type: 'dataset-geojson'
   - url: https://raw.githubusercontent.com/butchtm/unicef-ai4d-poverty-mapping/main/notebooks/2023-02-21-single-country-rollouts/rollout_output_tl.csv
     description: 'Country wide rollout (inference) of the Poverty Mapping Model on Timor Leste using 2.4km grids (bingtile quadkey level 14) as CSV'
     type: 'dataset-raw-csv'
 
-  - url: https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-02-tl_final_model_rollout.ipynb
+  - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-02-tl_final_model_rollout.ipynb
     description: 'Timor Leste Model Rollout Part 3 (Feature Engineering and Model Prediction on Rollout Grids)'
     type: 'code-notebook'
-  - url: https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023_02-21-tl_final_model_training.ipynb
+  - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023_02-21-tl_final_model_training.ipynb
     description: 'Timor Leste Model Rollout Part 1 (Training Final Single-country Model)'
     type: 'code-notebook'
-  - url: https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-01-tl_generate_populated_grids.ipynb
+  - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-01-tl_generate_populated_grids.ipynb
     description: 'Timor Leste Model Rollout Part 2 (Generate Roll-out Grids)'
     type: 'code-notebook'

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/no-null */
 import type { CatalogueItemType } from 'types/CatalogueItem.type'
 import HOME_PATH from '../constants'
 
@@ -11,12 +10,7 @@ export const fetchCatalogItems = async (): Promise<CatalogueItemType[]> => {
 
 export const fetchCatalogItem = async (
 	id: string
-): Promise<CatalogueItemType | null> => {
+): Promise<CatalogueItemType | undefined> => {
 	const catalog = await fetchCatalogItems()
-	const matchCatalog = catalog.filter(item => item.id === id)
-	if (matchCatalog.length > 0) {
-		const nextItem = matchCatalog[0]
-		return nextItem
-	}
-	return null
+	return catalog.find(item => item.id === id)
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,10 +1,10 @@
 import type { CatalogueItemType } from 'types/CatalogueItem.type'
+import HOME_PATH from '../constants'
 
-// eslint-disable-next-line import/prefer-default-export
 export const fetchCatalogItems = async (): Promise<CatalogueItemType[]> => {
-	const response = await fetch('/api/data/catalog.json') // Replace with your own JSON file path
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-	const catalog: CatalogueItemType[] = await response.json()
+	const response = await fetch(`${HOME_PATH}/api/data/catalog.json`)
+	const catalog: CatalogueItemType[] =
+		(await response.json()) as CatalogueItemType[]
 	return catalog
 }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/no-null */
 import type { CatalogueItemType } from 'types/CatalogueItem.type'
 import HOME_PATH from '../constants'
 
@@ -9,8 +10,13 @@ export const fetchCatalogItems = async (): Promise<CatalogueItemType[]> => {
 }
 
 export const fetchCatalogItem = async (
-	catalogItemId?: string
-): Promise<CatalogueItemType | undefined> => {
-	const catalogItems: CatalogueItemType[] = await fetchCatalogItems()
-	return catalogItems.find(item => item.id === catalogItemId)
+	id: string
+): Promise<CatalogueItemType | null> => {
+	const catalog = await fetchCatalogItems()
+	const matchCatalog = catalog.filter(item => item.id === id)
+	if (matchCatalog.length > 0) {
+		const nextItem = matchCatalog[0]
+		return nextItem
+	}
+	return null
 }

--- a/src/mocks/CatalogueItems.data.json
+++ b/src/mocks/CatalogueItems.data.json
@@ -13,16 +13,20 @@
 			"tags": ["poverty-mapping", "timor-leste"],
 			"country-region": "timor-leste",
 			"year-period": 2016,
-			"evaluation-metrics": {
-				"metric": {
-					"metric-type": "rsquared",
-					"value": 0.59
+			"evaluation-metrics": [
+				{
+					"metric": {
+						"metric-type": "rsquared",
+						"value": 0.59
+					}
 				},
-				"link": {
-					"description": "Additional evaluation metrics discussion",
-					"url": "https://thinkingmachines.github.io/unicef-ai4d-poverty-mapping/notebooks/2023-01-17-initial-model-ph-mm-tl-kh/model_tl.html#evaluate-model-training-using-cross-validation"
+				{
+					"link": {
+						"description": "Additional evaluation metrics discussion",
+						"url": "https://thinkingmachines.github.io/unicef-ai4d-poverty-mapping/notebooks/2023-01-17-initial-model-ph-mm-tl-kh/model_tl.html#evaluate-model-training-using-cross-validation"
+					}
 				}
-			},
+			],
 			"links": [
 				{
 					"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/model_tl_rollout.pkl",

--- a/src/mocks/CatalogueItems.data.json
+++ b/src/mocks/CatalogueItems.data.json
@@ -49,6 +49,228 @@
 					"type": "code-notebook"
 				}
 			]
+		},
+		{
+			"id": "povmap-philippines",
+			"name": "Poverty Mapping Model for Philippines",
+			"description": "This is a sklearn random forest regressor model  for predicting relative wealth for Philippines.  (add more details here later...)",
+			"card-type": "model",
+			"organization": {
+				"name": "Thinking Machines Data Sciences Inc",
+				"url": "https://thinkingmachin.es"
+			},
+			"date-added": "2023-03-02",
+			"tags": ["poverty-mapping", "philippines"],
+			"country-region": "philippines",
+			"year-period": 2017,
+			"evaluation-metrics": [
+				{
+					"metric": {
+						"metric-type": "rsquared",
+						"value": 0.59
+					}
+				},
+				{
+					"link": {
+						"description": "Additional evaluation metrics discussion",
+						"url": "https://thinkingmachines.github.io/unicef-ai4d-poverty-mapping/notebooks/2023-01-17-initial-model-ph-mm-ph-kh/model_ph.html#evaluate-model-training-using-cross-validation"
+					}
+				}
+			],
+			"links": [
+				{
+					"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/model_ph_rollout.pkl",
+					"description": "Philippines Poverty Mapping Model Weights (.pkl). See related notebooks for usage",
+					"type": "model-weights"
+				},
+				{
+					"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/rollout_output_ph.geojson",
+					"description": "Country wide rollout (inference) of the Poverty Mapping Model on Philippines using 2.4km grids (bingtile quadkey level 14)",
+					"type": "dataset-geojson"
+				},
+				{
+					"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-02-ph_final_model_rollout.ipynb",
+					"description": "Philippines Model Rollout Part 3 (Feature Engineering and Model Prediction on Rollout Grids)",
+					"type": "code-notebook"
+				},
+				{
+					"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023_02-21-ph_final_model_training.ipynb",
+					"description": "Philippines Model Rollout Part 1 (Training Final Single-country Model)",
+					"type": "code-notebook"
+				},
+				{
+					"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-01-ph_generate_populated_grids.ipynb",
+					"description": "Philippines Model Rollout Part 2 (Generate Roll-out Grids)",
+					"type": "code-notebook"
+				}
+			]
+		},
+		{
+			"id": "povmap-timor-leste-rollout-dataset",
+			"name": "Poverty Mapping Rollout Dataset for Timor Leste",
+			"description": "This is the rollout dataset of relative wealth predictions relative wealth for Timor Leste.  (add more details here later...)",
+			"card-type": "dataset",
+			"organization": {
+				"name": "Thinking Machines Data Sciences Inc",
+				"url": "https://thinkingmachin.es"
+			},
+			"date-added": "2023-03-02",
+			"tags": ["poverty-mapping", "timor-leste"],
+			"country-region": "timor-leste",
+			"year-period": 2016,
+			"links": [
+				{
+					"url": "https://raw.githubusercontent.com/thinkingmachines/unicef-ai4d-poverty-mapping/main/notebooks/2023-02-21-single-country-rollouts/rollout_output_tl.geojson",
+					"description": "Country wide rollout (inference) of the Poverty Mapping Model on Timor Leste using 2.4km grids (bingtile quadkey level 14) as geojson",
+					"type": "dataset-raw-geojson"
+				},
+				{
+					"url": "https://raw.githubusercontent.com/butchtm/unicef-ai4d-poverty-mapping/main/notebooks/2023-02-21-single-country-rollouts/rollout_output_tl.csv",
+					"description": "Country wide rollout (inference) of the Poverty Mapping Model on Timor Leste using 2.4km grids (bingtile quadkey level 14) as CSV",
+					"type": "dataset-raw-csv"
+				},
+				{
+					"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-02-tl_final_model_rollout.ipynb",
+					"description": "Timor Leste Model Rollout Part 3 (Feature Engineering and Model Prediction on Rollout Grids)",
+					"type": "code-notebook"
+				},
+				{
+					"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023_02-21-tl_final_model_training.ipynb",
+					"description": "Timor Leste Model Rollout Part 1 (Training Final Single-country Model)",
+					"type": "code-notebook"
+				},
+				{
+					"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-01-tl_generate_populated_grids.ipynb",
+					"description": "Timor Leste Model Rollout Part 2 (Generate Roll-out Grids)",
+					"type": "code-notebook"
+				}
+			],
+			"data-columns": [
+				{
+					"name": "quadkey",
+					"type": "string"
+				},
+				{
+					"name": "shapeName",
+					"type": "string"
+				},
+				{
+					"name": "shapeISO",
+					"type": "string"
+				},
+				{
+					"name": "shapeID",
+					"type": "string"
+				},
+				{
+					"name": "shapeGroup",
+					"type": "string"
+				},
+				{
+					"name": "shapeType",
+					"type": "string"
+				},
+				{
+					"name": "pop_count",
+					"type": "float"
+				},
+				{
+					"name": "Predicted Relative Wealth Index",
+					"type": "float"
+				},
+				{
+					"name": "Predicted Wealth Category (quintile)",
+					"type": "string"
+				},
+				{
+					"name": "Predicted Wealth Category (split-quintile)",
+					"type": "string"
+				},
+				{
+					"name": "geometry",
+					"type": "string"
+				}
+			],
+			"sample-data": [
+				[
+					31011220203121,
+					"Nitibe",
+					"None",
+					"TLS-ADM2-3_0_0-B58",
+					"TLS",
+					"ADM2",
+					102.251936,
+					-0.32614251865998456,
+					"E",
+					"E",
+					"POLYGON ((124.03564453125 -9.340672181980946, 124.03564453125 -9.318990192397923, 124.0576171875 -9.318990192397923, 124.0576171875 -9.340672181980946, 124.03564453125 -9.340672181980946))"
+				],
+				[
+					31011220203123,
+					"Nitibe",
+					"None",
+					"TLS-ADM2-3_0_0-B58",
+					"TLS",
+					"ADM2",
+					992.492772,
+					0.1447559201393492,
+					"C",
+					"C",
+					"POLYGON ((124.03564453125 -9.362352822055612, 124.03564453125 -9.340672181980946, 124.0576171875 -9.340672181980946, 124.0576171875 -9.362352822055612, 124.03564453125 -9.362352822055612))"
+				],
+				[
+					31011220203130,
+					"Nitibe",
+					"None",
+					"TLS-ADM2-3_0_0-B58",
+					"TLS",
+					"ADM2",
+					118.8976,
+					-0.31718538830078946,
+					"E",
+					"E",
+					"POLYGON ((124.0576171875 -9.340672181980946, 124.0576171875 -9.318990192397923, 124.07958984375 -9.318990192397923, 124.07958984375 -9.340672181980946, 124.0576171875 -9.340672181980946))"
+				],
+				[
+					31011220203132,
+					"Nitibe",
+					"None",
+					"TLS-ADM2-3_0_0-B58",
+					"TLS",
+					"ADM2",
+					513.637632,
+					0.07455815999209406,
+					"C",
+					"C",
+					"POLYGON ((124.0576171875 -9.362352822055612, 124.0576171875 -9.340672181980946, 124.07958984375 -9.340672181980946, 124.07958984375 -9.362352822055612, 124.0576171875 -9.362352822055612))"
+				],
+				[
+					31011220203310,
+					"Nitibe",
+					"None",
+					"TLS-ADM2-3_0_0-B58",
+					"TLS",
+					"ADM2",
+					319.14094,
+					-0.0210791963118972,
+					"C",
+					"C",
+					"POLYGON ((124.0576171875 -9.384032109601685, 124.0576171875 -9.362352822055612, 124.07958984375 -9.362352822055612, 124.07958984375 -9.384032109601685, 124.0576171875 -9.384032109601685))"
+				],
+				[
+					31011220203312,
+					"Nitibe",
+					"None",
+					"TLS-ADM2-3_0_0-B58",
+					"TLS",
+					"ADM2",
+					41.089748,
+					0.7565705461937821,
+					"A",
+					"A",
+					"POLYGON ((124.0576171875 -9.405710041600031, 124.0576171875 -9.384032109601685, 124.07958984375 -9.384032109601685, 124.07958984375 -9.405710041600031, 124.0576171875 -9.405710041600031))"
+				]
+			]
 		}
 	]
 }

--- a/src/pages/CatalogueItemPage.tsx
+++ b/src/pages/CatalogueItemPage.tsx
@@ -1,10 +1,7 @@
 import { fetchCatalogItem } from 'api'
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import type {
-	CatalogueItemType,
-	EvaluationMetricsType
-} from '../types/CatalogueItem.type'
+import type { CatalogueItemType } from '../types/CatalogueItem.type'
 
 const CatalogueItemPage = () => {
 	const { id } = useParams()
@@ -50,26 +47,33 @@ const CatalogueItemPage = () => {
 		links
 	} = catalogueItem
 
-	const evaluationMetricSection = (
-		evaluationMetric as EvaluationMetricsType[]
-	).map(evalItem => {
+	const evaluationMetricSection = evaluationMetric?.map(evalItem => {
 		const { metric, link } = evalItem
 		// Metric and link can be undefined so there is a need to check if it exists
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		if (metric) {
+		const metricItem = metric && (
+			<>
+				{metric['metric-type']} ({metric.value})
+			</>
+		)
+		const linkItem = link && (
+			<a href={link.url} target='_blank' rel='noreferrer'>
+				{link.description}
+			</a>
+		)
+		if (metric && link) {
 			return (
 				<div key={metric['metric-type']}>
-					{metric['metric-type']} ({metric.value})
+					{metricItem}
+					<br />
+					{linkItem}
 				</div>
 			)
 		}
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		if (metric) {
+			return <div key={metric['metric-type']}>{metricItem}</div>
+		}
 		if (link) {
-			return (
-				<a href={link.url} target='_blank' rel='noreferrer' key={link.url}>
-					{link.description}
-				</a>
-			)
+			return <div key={link.url}>{linkItem}</div>
 		}
 		return '-'
 	})
@@ -99,12 +103,14 @@ const CatalogueItemPage = () => {
 								<td className='font-bold'>Year/Period:</td>
 								<td>{yearPeriod}</td>
 							</tr>
-							<tr>
-								<td className='align-top font-bold'>Evaluation Metric:</td>
-								<td>
-									<div>{evaluationMetricSection}</div>
-								</td>
-							</tr>
+							{evaluationMetric !== undefined && (
+								<tr>
+									<td className='align-top font-bold'>Evaluation Metric:</td>
+									<td>
+										<div>{evaluationMetricSection}</div>
+									</td>
+								</tr>
+							)}
 						</tbody>
 					</table>
 				</section>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
 		"noEmit": true,
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
+		"sourceMap": true,
 		"strict": true,
 		"target": "ESNext",
 		"types": ["vite/client", "vitest/globals", "vite-plugin-pwa/client"]


### PR DESCRIPTION
* Make evaluation metrics section optional (for datasets)
* Allow both link and metric to coexist within the same evaluationMetric
* Add VITE_HOME_PATH to catalog json url 