### PR TITLE
Create initial filter context and get filter options

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -158,7 +158,8 @@
 			}
 		],
 		"unicorn/no-nested-ternary": ["error"],
-		"unicorn/prevent-abbreviations": "off"
+		"unicorn/prevent-abbreviations": "off",
+		"unicorn/no-array-reduce": "off"
 	},
 	"settings": {
 		"react": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import Header from 'components/Header'
 import { CatalogueItemProvider } from 'context/CatalogueItemContext'
+import { FilterProvider } from 'context/FilterContext'
 import { CatalogueItemPage, CataloguePage, LandingPage } from 'pages'
 import LoadCatalog from 'pages/LoadCatalog'
 import type { ReactElement } from 'react'
@@ -9,16 +10,21 @@ import HOME_PATH from './constants'
 export default function App(): ReactElement {
 	return (
 		<BrowserRouter>
+			<Header />
 			<CatalogueItemProvider>
-				<Header />
-				<Routes>
-					<Route path={`${HOME_PATH}/`} element={<LandingPage />} />
-					<Route path={`${HOME_PATH}/loadcatalog`} element={<LoadCatalog />} />
-					<Route path={`${HOME_PATH}/catalogue`}>
-						<Route index element={<CataloguePage />} />
-						<Route path=':id' element={<CatalogueItemPage />} />
-					</Route>
-				</Routes>
+				<FilterProvider>
+					<Routes>
+						<Route path={`${HOME_PATH}/`} element={<LandingPage />} />
+						<Route
+							path={`${HOME_PATH}/loadcatalog`}
+							element={<LoadCatalog />}
+						/>
+						<Route path={`${HOME_PATH}/catalogue`}>
+							<Route index element={<CataloguePage />} />
+							<Route path=':id' element={<CatalogueItemPage />} />
+						</Route>
+					</Routes>
+				</FilterProvider>
 			</CatalogueItemProvider>
 		</BrowserRouter>
 	)

--- a/src/context/FilterContext.tsx
+++ b/src/context/FilterContext.tsx
@@ -1,12 +1,18 @@
 import type { ReactNode } from 'react'
 import React, { useEffect, useMemo, useState } from 'react'
 import type { FilterOption } from '../types/SearchFilters.type'
-import { getFilterOptions } from '../utils/Filters.util'
+import {
+	getCountryOptions,
+	getOrganizationOptions,
+	getTagsOptions
+} from '../utils/Filters.util'
 import { useCatalogueItemContext } from './CatalogueItemContext'
 
 interface FilterContextType {
 	isFilterOptionsLoading: boolean
 	countries: FilterOption[]
+	organizations: FilterOption[]
+	tags: FilterOption[]
 }
 
 interface Properties {
@@ -19,12 +25,15 @@ export const FilterContext = React.createContext<FilterContextType>(
 
 export const FilterProvider = ({ children }: Properties) => {
 	const { catalogueItems } = useCatalogueItemContext()
+
 	const [isFilterOptionsLoading, setIsFilterOptionsLoading] = useState(true)
 	const [countries, setCountries] = useState<FilterOption[]>([])
+	const [organizations, setOrganizations] = useState<FilterOption[]>([])
+	const [tags, setTags] = useState<FilterOption[]>([])
 
 	const contextObj = useMemo(
-		() => ({ isFilterOptionsLoading, countries }),
-		[isFilterOptionsLoading, countries]
+		() => ({ isFilterOptionsLoading, countries, organizations, tags }),
+		[isFilterOptionsLoading, countries, organizations, tags]
 	)
 
 	useEffect(() => {
@@ -32,8 +41,14 @@ export const FilterProvider = ({ children }: Properties) => {
 
 		setIsFilterOptionsLoading(true)
 
-		const countryOptions = getFilterOptions('country-region', catalogueItems)
+		const countryOptions = getCountryOptions(catalogueItems)
 		setCountries(countryOptions)
+
+		const organizationOptions = getOrganizationOptions(catalogueItems)
+		setOrganizations(organizationOptions)
+
+		const tagOptions = getTagsOptions(catalogueItems)
+		setTags(tagOptions)
 
 		setIsFilterOptionsLoading(false)
 	}, [catalogueItems])

--- a/src/context/FilterContext.tsx
+++ b/src/context/FilterContext.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
+import type { FilterOption } from '../types/SearchFilters.type'
+import { getFilterOptions } from '../utils/Filters.util'
+import { useCatalogueItemContext } from './CatalogueItemContext'
+
+interface FilterContextType {
+	isFilterOptionsLoading: boolean
+	countries: FilterOption[]
+}
+
+interface Properties {
+	children: ReactNode
+}
+
+export const FilterContext = React.createContext<FilterContextType>(
+	{} as FilterContextType
+)
+
+export const FilterProvider = ({ children }: Properties) => {
+	const { catalogueItems } = useCatalogueItemContext()
+	const [isFilterOptionsLoading, setIsFilterOptionsLoading] = useState(true)
+	const [countries, setCountries] = useState<FilterOption[]>([])
+
+	const contextObj = useMemo(
+		() => ({ isFilterOptionsLoading, countries }),
+		[isFilterOptionsLoading, countries]
+	)
+
+	useEffect(() => {
+		if (catalogueItems.length === 0) return
+
+		setIsFilterOptionsLoading(true)
+
+		const countryOptions = getFilterOptions('country-region', catalogueItems)
+		setCountries(countryOptions)
+
+		setIsFilterOptionsLoading(false)
+	}, [catalogueItems])
+
+	return (
+		<FilterContext.Provider value={contextObj}>
+			{children}
+		</FilterContext.Provider>
+	)
+}
+
+export const useFilterContext = () => React.useContext(FilterContext)

--- a/src/pages/CataloguePage.tsx
+++ b/src/pages/CataloguePage.tsx
@@ -1,12 +1,8 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { AutoComplete, DatePicker, Select, Skeleton, Space } from 'antd'
-import { getOrganizationList, getTagList } from 'api'
 import CatalogueItemCard from 'components/CatalogueItemCard'
 import { useCatalogueItemContext } from 'context/CatalogueItemContext'
 import { useFilterContext } from 'context/FilterContext'
-import { useEffect, useState } from 'react'
-import type { ValueLabel } from 'types/SearchFilters.type'
-import { makeLabels } from 'utils/Filters.util'
 import CatalogueHeroImg from '../assets/catalogue-hero-bg.jpg'
 
 const { RangePicker } = DatePicker
@@ -16,29 +12,11 @@ const onTagsChange = () => {}
 const onOrganizationChange = () => {}
 
 const CataloguePage = () => {
-	const { catalogueItems, isLoading: isCatalogueItemsLoading } =
-		useCatalogueItemContext()
-	const { countries } = useFilterContext()
-	const [isLoading, setIsLoading] = useState(true)
-	const [orgList, setOrgList] = useState<ValueLabel[]>([])
-	const [tagList, setTagList] = useState<ValueLabel[]>([])
+	const { catalogueItems, isLoading } = useCatalogueItemContext()
+	const { countries, organizations, tags } = useFilterContext()
 	let catalogueItemsSection
 
-	useEffect(() => {
-		const fetchData = async () => {
-			setIsLoading(true)
-			const nextOrgList = await getOrganizationList()
-			const nextOrgLabels = makeLabels(nextOrgList)
-			setOrgList(nextOrgLabels)
-			const nextTagList = await getTagList()
-			const nextTagLabels = makeLabels(nextTagList)
-			setTagList(nextTagLabels)
-			setIsLoading(false)
-		}
-		void fetchData()
-	}, [])
-
-	if (isLoading || isCatalogueItemsLoading) {
+	if (isLoading) {
 		catalogueItemsSection = (
 			<div className='mt-3 p-3'>
 				<Skeleton />
@@ -117,7 +95,7 @@ const CataloguePage = () => {
 								placeholder='Select an organization...'
 								defaultValue={[]}
 								onChange={onOrganizationChange}
-								options={orgList}
+								options={organizations}
 							/>
 						</div>
 
@@ -129,7 +107,7 @@ const CataloguePage = () => {
 								style={{ width: '100%', marginTop: '8px' }}
 								placeholder='Select a tag...'
 								onChange={onTagsChange}
-								options={tagList}
+								options={tags}
 							/>
 						</div>
 					</Space>

--- a/src/pages/CataloguePage.tsx
+++ b/src/pages/CataloguePage.tsx
@@ -1,11 +1,12 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { AutoComplete, DatePicker, Select, Skeleton, Space } from 'antd'
-import { getCountryList, getOrganizationList, getTagList } from 'api'
+import { getOrganizationList, getTagList } from 'api'
 import CatalogueItemCard from 'components/CatalogueItemCard'
 import { useCatalogueItemContext } from 'context/CatalogueItemContext'
+import { useFilterContext } from 'context/FilterContext'
 import { useEffect, useState } from 'react'
 import type { ValueLabel } from 'types/SearchFilters.type'
-import makeLabels from 'utils/Filters.util'
+import { makeLabels } from 'utils/Filters.util'
 import CatalogueHeroImg from '../assets/catalogue-hero-bg.jpg'
 
 const { RangePicker } = DatePicker
@@ -17,8 +18,8 @@ const onOrganizationChange = () => {}
 const CataloguePage = () => {
 	const { catalogueItems, isLoading: isCatalogueItemsLoading } =
 		useCatalogueItemContext()
+	const { countries } = useFilterContext()
 	const [isLoading, setIsLoading] = useState(true)
-	const [countryList, setCountryList] = useState<ValueLabel[]>([])
 	const [orgList, setOrgList] = useState<ValueLabel[]>([])
 	const [tagList, setTagList] = useState<ValueLabel[]>([])
 	let catalogueItemsSection
@@ -26,9 +27,6 @@ const CataloguePage = () => {
 	useEffect(() => {
 		const fetchData = async () => {
 			setIsLoading(true)
-			const nextCountryList = await getCountryList()
-			const nextCountryLabels = makeLabels(nextCountryList)
-			setCountryList(nextCountryLabels)
 			const nextOrgList = await getOrganizationList()
 			const nextOrgLabels = makeLabels(nextOrgList)
 			setOrgList(nextOrgLabels)
@@ -96,7 +94,7 @@ const CataloguePage = () => {
 								placeholder='Select a country/region...'
 								defaultValue={[]}
 								onChange={onCountryRegionChange}
-								options={countryList}
+								options={countries}
 							/>
 						</div>
 

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,22 +1,20 @@
 import { Skeleton } from 'antd'
-import { getCountryList, getTagList } from 'api'
+import { getTagList } from 'api'
+import { useFilterContext } from 'context/FilterContext'
 import { useEffect, useState } from 'react'
 import type { ValueLabel } from 'types/SearchFilters.type'
-import makeLabels from 'utils/Filters.util'
+import { makeLabels } from 'utils/Filters.util'
 import LandingHeroImg from '../assets/landing-hero-bg.jpg'
 import Tag from '../components/Tag'
 
 const LandingPage = () => {
+	const { isFilterOptionsLoading, countries } = useFilterContext()
 	const [isLoading, setIsLoading] = useState(true)
-	const [countryList, setCountryList] = useState<ValueLabel[]>([])
 	const [tagList, setTagList] = useState<ValueLabel[]>([])
 
 	useEffect(() => {
 		const fetchData = async () => {
 			setIsLoading(true)
-			const nextCountryList = await getCountryList()
-			const nextCountryLabels = makeLabels(nextCountryList)
-			setCountryList(nextCountryLabels)
 			const nextTagList = await getTagList()
 			const nextTagLabels = makeLabels(nextTagList)
 			setTagList(nextTagLabels)
@@ -54,7 +52,7 @@ const LandingPage = () => {
 						BROWSE BY TAGS
 					</span>
 					<div className='flex flex-wrap gap-3 py-3'>
-						{isLoading ? (
+						{isFilterOptionsLoading || isLoading ? (
 							<Skeleton.Button active size='small' shape='default' />
 						) : (
 							tagList.map(tag => <Tag key={tag.label}>{tag.label}</Tag>)
@@ -66,10 +64,12 @@ const LandingPage = () => {
 						BROWSE BY COUNTRY/REGION
 					</span>
 					<div className='flex flex-wrap gap-3 py-3 text-cloud-burst'>
-						{isLoading ? (
+						{isFilterOptionsLoading || isLoading ? (
 							<Skeleton.Button active size='small' shape='default' />
 						) : (
-							countryList.map(tag => <Tag key={tag.label}>{tag.label}</Tag>)
+							countries.map(country => (
+								<Tag key={country.value}>{country.label}</Tag>
+							))
 						)}
 					</div>
 				</div>

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,27 +1,10 @@
 import { Skeleton } from 'antd'
-import { getTagList } from 'api'
 import { useFilterContext } from 'context/FilterContext'
-import { useEffect, useState } from 'react'
-import type { ValueLabel } from 'types/SearchFilters.type'
-import { makeLabels } from 'utils/Filters.util'
 import LandingHeroImg from '../assets/landing-hero-bg.jpg'
 import Tag from '../components/Tag'
 
 const LandingPage = () => {
-	const { isFilterOptionsLoading, countries } = useFilterContext()
-	const [isLoading, setIsLoading] = useState(true)
-	const [tagList, setTagList] = useState<ValueLabel[]>([])
-
-	useEffect(() => {
-		const fetchData = async () => {
-			setIsLoading(true)
-			const nextTagList = await getTagList()
-			const nextTagLabels = makeLabels(nextTagList)
-			setTagList(nextTagLabels)
-			setIsLoading(false)
-		}
-		void fetchData()
-	}, [])
+	const { isFilterOptionsLoading, countries, tags } = useFilterContext()
 
 	return (
 		<div className='min-h-[calc(100vh_-_3rem)] bg-white'>
@@ -52,10 +35,10 @@ const LandingPage = () => {
 						BROWSE BY TAGS
 					</span>
 					<div className='flex flex-wrap gap-3 py-3'>
-						{isFilterOptionsLoading || isLoading ? (
+						{isFilterOptionsLoading ? (
 							<Skeleton.Button active size='small' shape='default' />
 						) : (
-							tagList.map(tag => <Tag key={tag.label}>{tag.label}</Tag>)
+							tags.map(tag => <Tag key={tag.value}>{tag.value}</Tag>)
 						)}
 					</div>
 				</div>
@@ -64,7 +47,7 @@ const LandingPage = () => {
 						BROWSE BY COUNTRY/REGION
 					</span>
 					<div className='flex flex-wrap gap-3 py-3 text-cloud-burst'>
-						{isFilterOptionsLoading || isLoading ? (
+						{isFilterOptionsLoading ? (
 							<Skeleton.Button active size='small' shape='default' />
 						) : (
 							countries.map(country => (

--- a/src/types/SearchFilters.type.ts
+++ b/src/types/SearchFilters.type.ts
@@ -2,3 +2,9 @@ export interface ValueLabel {
 	label: string | undefined
 	value: string | undefined
 }
+
+export interface FilterOption {
+	label: string
+	value: string
+	catalogueIds: string[]
+}

--- a/src/types/SearchFilters.type.ts
+++ b/src/types/SearchFilters.type.ts
@@ -6,5 +6,5 @@ export interface ValueLabel {
 export interface FilterOption {
 	label: string
 	value: string
-	catalogueIds: string[]
+	catalogueIds: Set<string>
 }

--- a/src/utils/Filters.util.ts
+++ b/src/utils/Filters.util.ts
@@ -1,8 +1,30 @@
-import type { ValueLabel } from 'types/SearchFilters.type'
+import type { CatalogueItemType } from 'types/CatalogueItem.type'
+import type { FilterOption, ValueLabel } from 'types/SearchFilters.type'
 
-const makeLabels = (items: (string | undefined)[]): ValueLabel[] =>
+export const makeLabels = (items: (string | undefined)[]): ValueLabel[] =>
 	items
 		.filter(item => item !== undefined)
 		.map(item => ({ label: item, value: item }))
 
-export default makeLabels
+export const getFilterOptions = (
+	filterKey: keyof CatalogueItemType,
+	catalogueItems: CatalogueItemType[]
+): FilterOption[] =>
+	catalogueItems.reduce<FilterOption[]>((acc, item) => {
+		if (!item[filterKey]) {
+			return acc
+		}
+
+		const entry = acc.find(obj => obj.value === item[filterKey])
+		if (entry) {
+			entry.catalogueIds.push(item.id)
+			return acc
+		}
+
+		acc.push({
+			catalogueIds: [item.id],
+			label: item[filterKey] as string,
+			value: item[filterKey] as string
+		})
+		return acc
+	}, [])

--- a/src/utils/Filters.util.ts
+++ b/src/utils/Filters.util.ts
@@ -1,30 +1,65 @@
 import type { CatalogueItemType } from 'types/CatalogueItem.type'
-import type { FilterOption, ValueLabel } from 'types/SearchFilters.type'
+import type { FilterOption } from 'types/SearchFilters.type'
 
-export const makeLabels = (items: (string | undefined)[]): ValueLabel[] =>
-	items
-		.filter(item => item !== undefined)
-		.map(item => ({ label: item, value: item }))
-
-export const getFilterOptions = (
-	filterKey: keyof CatalogueItemType,
+export const getCountryOptions = (
 	catalogueItems: CatalogueItemType[]
 ): FilterOption[] =>
 	catalogueItems.reduce<FilterOption[]>((acc, item) => {
-		if (!item[filterKey]) {
+		const { 'country-region': countryRegion, id } = item
+
+		if (!countryRegion) {
 			return acc
 		}
 
-		const entry = acc.find(obj => obj.value === item[filterKey])
-		if (entry) {
-			entry.catalogueIds.push(item.id)
+		const countryObj = acc.find(obj => obj.value === countryRegion)
+		if (countryObj) {
+			countryObj.catalogueIds.push(id)
+			return acc
+		}
+
+		acc.push({ catalogueIds: [id], label: countryRegion, value: countryRegion })
+		return acc
+	}, [])
+
+export const getOrganizationOptions = (
+	catalogueItems: CatalogueItemType[]
+): FilterOption[] =>
+	catalogueItems.reduce<FilterOption[]>((acc, item) => {
+		const { organization, id } = item
+
+		const orgObj = acc.find(obj => obj.value === organization.name)
+		if (orgObj) {
+			orgObj.catalogueIds.push(id)
 			return acc
 		}
 
 		acc.push({
-			catalogueIds: [item.id],
-			label: item[filterKey] as string,
-			value: item[filterKey] as string
+			catalogueIds: [id],
+			label: organization.name,
+			value: organization.name
 		})
+
+		return acc
+	}, [])
+
+export const getTagsOptions = (
+	catalogueItems: CatalogueItemType[]
+): FilterOption[] =>
+	catalogueItems.reduce<FilterOption[]>((acc, item) => {
+		const { tags, id } = item
+
+		if (!tags) {
+			return acc
+		}
+
+		for (const tag of tags) {
+			const tagObj = acc.find(obj => obj.value === tag)
+			if (tagObj) {
+				tagObj.catalogueIds.push(id)
+			} else {
+				acc.push({ catalogueIds: [id], label: tag, value: tag })
+			}
+		}
+
 		return acc
 	}, [])

--- a/src/utils/Filters.util.ts
+++ b/src/utils/Filters.util.ts
@@ -13,11 +13,15 @@ export const getCountryOptions = (
 
 		const countryObj = acc.find(obj => obj.value === countryRegion)
 		if (countryObj) {
-			countryObj.catalogueIds.push(id)
+			countryObj.catalogueIds.add(id)
 			return acc
 		}
 
-		acc.push({ catalogueIds: [id], label: countryRegion, value: countryRegion })
+		acc.push({
+			catalogueIds: new Set(id),
+			label: countryRegion,
+			value: countryRegion
+		})
 		return acc
 	}, [])
 
@@ -29,12 +33,12 @@ export const getOrganizationOptions = (
 
 		const orgObj = acc.find(obj => obj.value === organization.name)
 		if (orgObj) {
-			orgObj.catalogueIds.push(id)
+			orgObj.catalogueIds.add(id)
 			return acc
 		}
 
 		acc.push({
-			catalogueIds: [id],
+			catalogueIds: new Set(id),
 			label: organization.name,
 			value: organization.name
 		})
@@ -55,9 +59,9 @@ export const getTagsOptions = (
 		for (const tag of tags) {
 			const tagObj = acc.find(obj => obj.value === tag)
 			if (tagObj) {
-				tagObj.catalogueIds.push(id)
+				tagObj.catalogueIds.add(id)
 			} else {
-				acc.push({ catalogueIds: [id], label: tag, value: tag })
+				acc.push({ catalogueIds: new Set(id), label: tag, value: tag })
 			}
 		}
 


### PR DESCRIPTION
This PR includes:
- loading the filter options for country, organization, and tags. filter functionality will go on the next PR
- updating the schema of the filter options to this:
```
tags = [
{ label: string, value: string, catalogueIds: Set<string> },
{ label: string, value: string, catalogueIds: Set<string> },
]
```
In this example, the `label` and `value` will have the unique tag value while the `catalogueIds` is the list of ids that has that tag. I thought it's more flexible this way and easier to filter in the front-end. I was able to remove the transform function `makeLabels` also since this schema fit with the filter component data schema.

All unused functions / components will be cleaned up in another PR!