### PR TITLE
Add styling to catalogue item page + new fields

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,6 +50,12 @@
 			}
 		],
 		"no-void": "off",
+		"no-param-reassign": [
+			2,
+			{
+				"props": false
+			}
+		],
 
 		"@typescript-eslint/padding-line-between-statements": "off",
 		"@typescript-eslint/prefer-enum-initializers": "off",

--- a/catalog/airquality-thailand-model.yml
+++ b/catalog/airquality-thailand-model.yml
@@ -29,3 +29,11 @@ links:
   - url: https://github.com/thinkingmachines/unicef-ai4d-air-quality
     description: 'UNICEF AI4D Air Quality Github Repository'
     type: 'repository'
+
+  - url: https://drive.google.com/file/d/1lzGiUWpQ_vzyvY9FfDjWEH21Hiu-H9lz/view
+    description: 'Modelling of Daily PM2.5 in Thailand using Machine Learning on Remote Sensing Datasets'
+    type: research-paper
+
+  - url: https://drive.google.com/file/d/1lzGiUWpQ_vzyvY9FfDjWEH21Hiu-H9lz/view
+    description: 'Limitations of using the model'
+    type: limitations

--- a/catalog/povmap-philippines.yml
+++ b/catalog/povmap-philippines.yml
@@ -39,3 +39,6 @@ links:
   - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023_02-21-ph_final_model_training.ipynb
     description: 'Philippines Model Rollout Part 3 (Feature Engineering and Model Prediction on Rollout Grids)'
     type: 'code-notebook'
+  - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/feat/convert-geojsons-to-csvs/notebooks/2023-02-21-single-country-rollouts/rollout_output_tl.geojson
+    description: 'Training dataset for Poverty Mapping Model on Philippines'
+    type: 'training-dataset-geojson'

--- a/catalog/povmap-timor-leste.yml
+++ b/catalog/povmap-timor-leste.yml
@@ -39,3 +39,6 @@ links:
   - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/2023-03-01-tl_generate_populated_grids.ipynb
     description: 'Timor Leste Model Rollout Part 2 (Generate Roll-out Grids)'
     type: 'code-notebook'
+  - url: https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/rollout_output_tl.csv
+    description: 'Training dataset for Poverty Mapping Model on Timor Leste'
+    type: 'training-dataset-csv'

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"validate-catalog": "python scripts/validate_catalog.py"
 	},
 	"dependencies": {
+		"@ant-design/icons": "^5.0.1",
 		"@tanstack/react-query": "4.26.0",
 		"antd": "^5.3.1",
 		"dayjs": "^1.11.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ overrides:
   headers-polyfill: 3.1.2
 
 dependencies:
+  '@ant-design/icons':
+    specifier: ^5.0.1
+    version: 5.0.1(react-dom@18.2.0)(react@18.2.0)
   '@tanstack/react-query':
     specifier: 4.26.0
     version: 4.26.0(react-dom@18.2.0)(react@18.2.0)
@@ -4147,6 +4150,7 @@ packages:
         integrity: sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==
       }
     engines: { node: ^10 || ^12 || >=14 }
+    hasBin: true
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
@@ -5779,6 +5783,7 @@ packages:
       {
         integrity: sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==
       }
+    hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
@@ -8655,6 +8660,7 @@ packages:
         integrity: sha512-oqMvUXm1bMbwvGpoXAQVz8vXXQyQyx52HBDg3EDOK+dFXkQHssgkXEG4LfMwwZyr2Qt18I/w04XPaY4BkFTkzA==
       }
     engines: { node: '>=14' }
+    hasBin: true
     requiresBuild: true
     peerDependencies:
       typescript: '>= 4.4.x <= 4.9.x'
@@ -11442,6 +11448,7 @@ packages:
         integrity: sha512-U44lELgLZhbAD/xy/vncZ2Pq8sh2TnpiPvo38Ifg9+zeioR+LAkHu0i6YORIOxFafZoVg0xqQwex6e6F25S5XA==
       }
     engines: { node: '>= 12' }
+    hasBin: true
     peerDependencies:
       stylelint: '>= 11.x < 15'
     dependencies:
@@ -11614,6 +11621,7 @@ packages:
         integrity: sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==
       }
     engines: { node: '>=12.13.0' }
+    hasBin: true
     peerDependencies:
       postcss: ^8.0.9
     dependencies:
@@ -11850,6 +11858,7 @@ packages:
       {
         integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
       }
+    hasBin: true
     peerDependencies:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
@@ -11884,6 +11893,7 @@ packages:
         integrity: sha512-H3DWlwKpow+GpVLm/2cpmok72pwRr1YFROV3YzAmvzfGFiC1zEM/mc9b7+1XnrxuXtEbhJ7xUSIqjPFbedp7aQ==
       }
     engines: { node: ^14.13.1 || ^16 || >=18, pnpm: ^7.18.0 }
+    hasBin: true
     peerDependencies:
       typescript: ^4.3.5
     peerDependenciesMeta:
@@ -12152,6 +12162,7 @@ packages:
       {
         integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==
       }
+    hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
@@ -12165,6 +12176,7 @@ packages:
       {
         integrity: sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==
       }
+    hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
@@ -12332,6 +12344,7 @@ packages:
         integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==
       }
     engines: { node: ^14.18.0 || >=16.0.0 }
+    hasBin: true
     peerDependencies:
       '@types/node': '>= 14'
       less: '*'
@@ -12368,6 +12381,7 @@ packages:
         integrity: sha512-ydK9IGbAvoY8wkg29DQ4ivcVviCaUi3ivuPKfZEVddMTenFHUfB8EEDXQV8+RasEk1ACFLgMUqAaDuQ/Nk+mQA==
       }
     engines: { node: '>=v14.16.0' }
+    hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@vitest/browser': '*'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { ConfigProvider } from 'antd'
 import Header from 'components/Header'
 import { CatalogueItemProvider } from 'context/CatalogueItemContext'
 import { FilterProvider } from 'context/FilterContext'
@@ -11,24 +12,33 @@ import HOME_PATH from './constants'
 export default function App(): ReactElement {
 	return (
 		<BrowserRouter>
-			<Header />
-			<CatalogueItemProvider>
-				<FilterProvider>
-					<SearchProvider>
-						<Routes>
-							<Route path={`${HOME_PATH}/`} element={<LandingPage />} />
-							<Route
-								path={`${HOME_PATH}/loadcatalog`}
-								element={<LoadCatalog />}
-							/>
-							<Route path={`${HOME_PATH}/catalogue`}>
-								<Route index element={<CataloguePage />} />
-								<Route path=':id' element={<CatalogueItemPage />} />
-							</Route>
-						</Routes>
-					</SearchProvider>
-				</FilterProvider>
-			</CatalogueItemProvider>
+			<ConfigProvider
+				theme={{
+					token: {
+						colorPrimary: '#24295C',
+						colorLinkHover: '#24295C'
+					}
+				}}
+			>
+				<Header />
+				<CatalogueItemProvider>
+					<FilterProvider>
+						<SearchProvider>
+							<Routes>
+								<Route path={`${HOME_PATH}/`} element={<LandingPage />} />
+								<Route
+									path={`${HOME_PATH}/loadcatalog`}
+									element={<LoadCatalog />}
+								/>
+								<Route path={`${HOME_PATH}/catalogue`}>
+									<Route index element={<CataloguePage />} />
+									<Route path=':id' element={<CatalogueItemPage />} />
+								</Route>
+							</Routes>
+						</SearchProvider>
+					</FilterProvider>
+				</CatalogueItemProvider>
+			</ConfigProvider>
 		</BrowserRouter>
 	)
 }

--- a/src/components/CatalogueItemData.tsx
+++ b/src/components/CatalogueItemData.tsx
@@ -1,28 +1,111 @@
+/* eslint-disable react/jsx-handler-names */
+import { CopyOutlined } from '@ant-design/icons'
 import type { CatalogueItemType } from 'types/CatalogueItem.type'
+import { getFileFormat } from 'utils/String.util'
 
 interface Props {
 	catalogueItem: CatalogueItemType
 }
 
+const onCopyToClipboard = async (text: string) => {
+	await navigator.clipboard.writeText(text)
+}
+
 const CatalogueItemData = ({ catalogueItem }: Props) => {
 	const { links } = catalogueItem
 
+	const trainingDatasets = links.filter(link =>
+		link.type.includes('training-dataset')
+	)
+
+	const datasets = links.filter(link => link.type.startsWith('dataset-'))
+
+	let trainingDatasetSection
+	if (trainingDatasets.length > 0) {
+		trainingDatasetSection = (
+			<div className='mt-3 flex flex-col gap-3'>
+				<span className='mb-3 font-semibold text-gray-700'>
+					Training Dataset
+				</span>
+				{trainingDatasets.map(dataset => (
+					<div className='flex flex-row items-center' key={dataset.description}>
+						<div className='w-2/3'>
+							<a
+								href={dataset.url}
+								key={`${dataset.description}`}
+								target='_blank'
+								rel='noreferrer'
+								className='hover:underline'
+							>
+								{dataset.description}
+							</a>
+							<span className='ml-3 rounded-3xl bg-gray-200 py-1 px-2 text-xs font-semibold text-gray-600'>
+								{getFileFormat(dataset.type, 'training-dataset-').toUpperCase()}
+							</span>
+						</div>
+						<button
+							type='button'
+							className='ml-auto rounded bg-cloud-burst p-2 tracking-tight text-white hover:bg-opacity-95'
+							onClick={() => {
+								void onCopyToClipboard(dataset.url)
+							}}
+						>
+							<CopyOutlined style={{ marginRight: '8px' }} />
+							Copy link
+						</button>
+					</div>
+				))}
+			</div>
+		)
+	}
+
+	let rawDatasetsSection
+	if (datasets.length > 0) {
+		rawDatasetsSection = (
+			<div className='mt-3 flex flex-col gap-3'>
+				<span className='mb-3 font-semibold text-gray-700'>
+					Results Datasets
+				</span>
+				{datasets.map(dataset => (
+					<div className='flex flex-row items-center' key={dataset.description}>
+						<div className='w-2/3'>
+							<a
+								href={dataset.url}
+								key={`${dataset.description}`}
+								target='_blank'
+								rel='noreferrer'
+								className='hover:underline'
+							>
+								{dataset.description}
+							</a>
+							<span className='ml-3 rounded-3xl bg-gray-200 py-1 px-2 text-xs font-semibold text-gray-600'>
+								{dataset.type.includes('raw')
+									? getFileFormat(dataset.type, 'dataset-raw-').toUpperCase()
+									: getFileFormat(dataset.type, 'dataset-').toUpperCase()}
+							</span>
+						</div>
+						{dataset.type.includes('raw') && (
+							<button
+								type='button'
+								className='ml-auto rounded bg-cloud-burst p-2 tracking-tight text-white hover:bg-opacity-95'
+								onClick={() => {
+									void onCopyToClipboard(dataset.url)
+								}}
+							>
+								<CopyOutlined style={{ marginRight: '8px' }} />
+								Copy link
+							</button>
+						)}
+					</div>
+				))}
+			</div>
+		)
+	}
+
 	return (
-		<div className='mb-5 grid-cols-1 divide-y divide-gray-100'>
-			{links.map(link => (
-				<div key={link.url} className='align-center flex flex-col rounded p-5'>
-					<span className='text-xs text-gray-600'>{link.type}</span>
-					<a
-						href={link.url}
-						key={`${link.description}`}
-						target='_blank'
-						rel='noreferrer'
-						className='w-full hover:underline'
-					>
-						{link.description}
-					</a>
-				</div>
-			))}
+		<div className='mb-5 flex flex-col gap-6'>
+			{trainingDatasetSection}
+			{rawDatasetsSection}
 		</div>
 	)
 }

--- a/src/components/CatalogueItemData.tsx
+++ b/src/components/CatalogueItemData.tsx
@@ -1,0 +1,30 @@
+import type { CatalogueItemType } from 'types/CatalogueItem.type'
+
+interface Props {
+	catalogueItem: CatalogueItemType
+}
+
+const CatalogueItemData = ({ catalogueItem }: Props) => {
+	const { links } = catalogueItem
+
+	return (
+		<div className='mb-5 grid-cols-1 divide-y divide-gray-100'>
+			{links.map(link => (
+				<div key={link.url} className='align-center flex flex-col rounded p-5'>
+					<span className='text-xs text-gray-600'>{link.type}</span>
+					<a
+						href={link.url}
+						key={`${link.description}`}
+						target='_blank'
+						rel='noreferrer'
+						className='w-full hover:underline'
+					>
+						{link.description}
+					</a>
+				</div>
+			))}
+		</div>
+	)
+}
+
+export default CatalogueItemData

--- a/src/components/CatalogueItemData.tsx
+++ b/src/components/CatalogueItemData.tsx
@@ -23,8 +23,8 @@ const CatalogueItemData = ({ catalogueItem }: Props) => {
 	let trainingDatasetSection
 	if (trainingDatasets.length > 0) {
 		trainingDatasetSection = (
-			<div className='mt-3 flex flex-col gap-3'>
-				<span className='mb-3 font-semibold text-gray-700'>
+			<div className='flex flex-col gap-2'>
+				<span className='mb-1 font-semibold text-gray-700'>
 					Training Dataset
 				</span>
 				{trainingDatasets.map(dataset => (
@@ -62,8 +62,8 @@ const CatalogueItemData = ({ catalogueItem }: Props) => {
 	let rawDatasetsSection
 	if (datasets.length > 0) {
 		rawDatasetsSection = (
-			<div className='mt-3 flex flex-col gap-3'>
-				<span className='mb-3 font-semibold text-gray-700'>
+			<div className='flex flex-col gap-2'>
+				<span className='mb-1 font-semibold text-gray-700'>
 					Results Datasets
 				</span>
 				{datasets.map(dataset => (

--- a/src/components/CatalogueItemLinks.tsx
+++ b/src/components/CatalogueItemLinks.tsx
@@ -1,0 +1,49 @@
+import type { CatalogueItemType, LinkType } from 'types/CatalogueItem.type'
+import { formatString } from 'utils/String.util'
+
+interface Props {
+	catalogueItem: CatalogueItemType
+}
+
+const CatalogueItemLinks = ({ catalogueItem }: Props) => {
+	const { links } = catalogueItem
+
+	const groupedLinks = links
+		.filter(link => !link.type.includes('dataset'))
+		.reduce((grouped: Record<string, LinkType[]>, link: LinkType) => {
+			const { type } = link
+			grouped[type] ??= []
+			grouped[type].push(link)
+			return grouped
+		}, {})
+
+	let relatedLinksSection
+	if (Object.keys(groupedLinks).length > 0) {
+		relatedLinksSection = (
+			<div className='mb-5 flex flex-col gap-6'>
+				{Object.keys(groupedLinks).map(linkType => (
+					<div className='flex flex-col gap-2' key={linkType}>
+						<span className='mb-1 font-semibold text-gray-700'>
+							{formatString(linkType)}
+						</span>
+						{groupedLinks[linkType].map(link => (
+							<a
+								href={link.url}
+								key={link.description}
+								target='_blank'
+								rel='noreferrer'
+								className='hover:underline'
+							>
+								{link.description}
+							</a>
+						))}
+					</div>
+				))}
+			</div>
+		)
+	}
+
+	return <div>{relatedLinksSection}</div>
+}
+
+export default CatalogueItemLinks

--- a/src/components/CatalogueItemOverview.tsx
+++ b/src/components/CatalogueItemOverview.tsx
@@ -1,3 +1,4 @@
+import { InfoCircleOutlined } from '@ant-design/icons'
 import type { CatalogueItemType } from 'types/CatalogueItem.type'
 
 interface Props {
@@ -11,34 +12,52 @@ const CatalogueItemOverview = ({ catalogueItem }: Props) => {
 		const { metric, link } = evalItem
 		// Metric and link can be undefined so there is a need to check if it exists
 		const metricItem = metric && (
-			<>
-				{metric['metric-type']} ({metric.value})
-			</>
+			<div className='flex flex-col'>
+				<span className='text-xs font-semibold text-cloud-burst'>
+					{metric['metric-type'].toUpperCase()}
+				</span>
+				<span className='text-2xl font-semibold text-cloud-burst'>
+					{metric.value}
+				</span>
+			</div>
 		)
 		const linkItem = link && (
-			<a
-				href={link.url}
-				target='_blank'
-				rel='noreferrer'
-				className='hover:underline'
-			>
-				{link.description}
-			</a>
+			<div className='self-center'>
+				<InfoCircleOutlined style={{ marginRight: '8px' }} />
+				<a
+					href={link.url}
+					target='_blank'
+					rel='noreferrer'
+					className='hover:underline'
+				>
+					{link.description}
+				</a>
+			</div>
 		)
 		if (metric && link) {
 			return (
-				<div className='' key={metric['metric-type']}>
+				<div
+					className='align-center mt-3 flex grid-rows-1 flex-row gap-5 p-5'
+					key={metric['metric-type']}
+				>
 					{metricItem}
-					<br />
 					{linkItem}
 				</div>
 			)
 		}
 		if (metric) {
-			return <div key={metric['metric-type']}>{metricItem}</div>
+			return (
+				<div className='p-5' key={metric['metric-type']}>
+					{metricItem}
+				</div>
+			)
 		}
 		if (link) {
-			return <div key={link.url}>{linkItem}</div>
+			return (
+				<div className='p-5' key={link.url}>
+					{linkItem}
+				</div>
+			)
 		}
 		return '-'
 	})
@@ -47,8 +66,8 @@ const CatalogueItemOverview = ({ catalogueItem }: Props) => {
 			<p className='mb-5 text-gray-600'>{description}</p>
 			{evaluationMetric !== undefined && (
 				<div className='flex flex-col'>
-					<span className='font-semibold'>Evaluation Metric</span>
-					<div className='flex flex-col gap-3 text-gray-600'>
+					<span className='font-semibold text-gray-600'>Evaluation Metric</span>
+					<div className='grid-cols-1 gap-5 divide-y divide-gray-200 text-gray-600'>
 						{evaluationMetricSection}
 					</div>
 				</div>

--- a/src/components/CatalogueItemOverview.tsx
+++ b/src/components/CatalogueItemOverview.tsx
@@ -1,0 +1,60 @@
+import type { CatalogueItemType } from 'types/CatalogueItem.type'
+
+interface Props {
+	catalogueItem: CatalogueItemType
+}
+
+const CatalogueItemOverview = ({ catalogueItem }: Props) => {
+	const { description, 'evaluation-metrics': evaluationMetric } = catalogueItem
+
+	const evaluationMetricSection = evaluationMetric?.map(evalItem => {
+		const { metric, link } = evalItem
+		// Metric and link can be undefined so there is a need to check if it exists
+		const metricItem = metric && (
+			<>
+				{metric['metric-type']} ({metric.value})
+			</>
+		)
+		const linkItem = link && (
+			<a
+				href={link.url}
+				target='_blank'
+				rel='noreferrer'
+				className='hover:underline'
+			>
+				{link.description}
+			</a>
+		)
+		if (metric && link) {
+			return (
+				<div className='' key={metric['metric-type']}>
+					{metricItem}
+					<br />
+					{linkItem}
+				</div>
+			)
+		}
+		if (metric) {
+			return <div key={metric['metric-type']}>{metricItem}</div>
+		}
+		if (link) {
+			return <div key={link.url}>{linkItem}</div>
+		}
+		return '-'
+	})
+	return (
+		<div>
+			<p className='mb-5 text-gray-600'>{description}</p>
+			{evaluationMetric !== undefined && (
+				<div className='flex flex-col'>
+					<span className='font-semibold'>Evaluation Metric</span>
+					<div className='flex flex-col gap-3 text-gray-600'>
+						{evaluationMetricSection}
+					</div>
+				</div>
+			)}
+		</div>
+	)
+}
+
+export default CatalogueItemOverview

--- a/src/components/CatalogueItemOverview.tsx
+++ b/src/components/CatalogueItemOverview.tsx
@@ -66,7 +66,7 @@ const CatalogueItemOverview = ({ catalogueItem }: Props) => {
 			<p className='mb-5 text-gray-600'>{description}</p>
 			{evaluationMetric !== undefined && (
 				<div className='flex flex-col'>
-					<span className='font-semibold text-gray-600'>Evaluation Metric</span>
+					<span className='font-semibold text-gray-700'>Evaluation Metric</span>
 					<div className='grid-cols-1 gap-5 divide-y divide-gray-200 text-gray-600'>
 						{evaluationMetricSection}
 					</div>

--- a/src/pages/CatalogueItemPage.tsx
+++ b/src/pages/CatalogueItemPage.tsx
@@ -1,9 +1,11 @@
+import { CalendarOutlined, EnvironmentOutlined } from '@ant-design/icons'
 import { Skeleton } from 'antd'
 import { useCatalogueItemContext } from 'context/CatalogueItemContext'
 import { useFilterContext } from 'context/FilterContext'
-
+import dayjs from 'dayjs'
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import formatString from 'utils/String.util'
 import Tag from '../components/Tag'
 import type { CatalogueItemType } from '../types/CatalogueItem.type'
 
@@ -155,11 +157,11 @@ const CatalogueItemPage = () => {
 			<div className='flex flex-col md:flex-row'>
 				<div className='flex w-full flex-col gap-4 p-10 text-cloud-burst md:w-2/3'>
 					<section className='mb-5'>
-						<span className='text-sm font-semibold'>SUMMARY</span>
+						<span className='text-sm font-semibold'>Overview</span>
 						<p className='mx-5 mt-3 text-gray-600'>{description}</p>
 					</section>
 					<section>
-						<h2 className='mt-5 text-sm font-semibold'>PROPERTIES</h2>
+						<h2 className='mt-5 text-sm font-semibold'>Properties</h2>
 						<table className='mt-3 mb-5 border-separate border-spacing-x-5 border-spacing-y-2'>
 							<tbody>
 								<tr>
@@ -184,7 +186,7 @@ const CatalogueItemPage = () => {
 						</table>
 					</section>
 					<section>
-						<h2 className='mt-5 mb-3 text-sm font-semibold'>DATA</h2>
+						<h2 className='mt-5 mb-3 text-sm font-semibold'>Data</h2>
 						<div className='mb-5 grid-cols-1 divide-y divide-gray-100'>
 							{links.map(link => (
 								<div
@@ -206,9 +208,73 @@ const CatalogueItemPage = () => {
 						</div>
 					</section>
 				</div>
-				<div className='flex w-full flex-col p-10 text-cloud-burst md:w-1/3 '>
+				<div className='flex w-full flex-col gap-5 p-10 text-cloud-burst md:w-1/3'>
+					<div className='rounded bg-gray-50 p-6'>
+						<span className='font-semibold'>Details</span>
+						<div className='flex flex-col gap-5'>
+							<div className='align-center mt-5 flex flex-row gap-3'>
+								<EnvironmentOutlined
+									style={{
+										color: '#6b7280',
+										fontSize: '24px',
+										margin: 'auto 0'
+									}}
+								/>
+								<div className='flex flex-col'>
+									<span className='text-xs font-medium text-gray-500'>
+										COUNTRY / REGION
+									</span>
+									<span className='font-medium'>
+										{countryRegion ? formatString(countryRegion) : '-'}
+									</span>
+								</div>
+							</div>
+							<div className='align-center flex flex-row gap-3'>
+								<CalendarOutlined
+									style={{
+										color: '#6b7280',
+										fontSize: '24px',
+										margin: 'auto 0'
+									}}
+								/>
+								<div className='flex flex-col'>
+									<span className='text-xs font-medium text-gray-500'>
+										YEAR / PERIOD
+									</span>
+									<span className='font-medium'>{yearPeriod ?? '-'}</span>
+								</div>
+							</div>
+							<div className='align-center flex flex-row gap-3'>
+								<CalendarOutlined
+									style={{
+										color: '#6b7280',
+										fontSize: '24px',
+										margin: 'auto 0'
+									}}
+								/>
+								<div className='flex flex-col'>
+									<span className='text-xs font-medium text-gray-500'>
+										DATE CREATED
+									</span>
+									<span className='font-medium'>
+										{dayjs(dateAdded).format('MMM DD, YYYY')}
+									</span>
+								</div>
+							</div>
+							{dateModified ? (
+								<div className='flex flex-col'>
+									<span className='text-xs font-medium text-gray-500'>
+										DATE UPDATED
+									</span>
+									<span className='font-medium'>
+										{dayjs(dateModified).format('MMM DD, YYYY')}
+									</span>
+								</div>
+							) : undefined}
+						</div>
+					</div>
 					<div className='rounded bg-gray-50 p-5'>
-						<span className='text-sm font-semibold'>TAGS</span>
+						<span className='text-sm font-semibold'>Tags</span>
 						<div className='flex flex-wrap gap-3 py-3'>
 							{tags?.map(tag => (
 								<Tag key={tag} value={tag} onFilterClick={onTagClick}>

--- a/src/pages/CatalogueItemPage.tsx
+++ b/src/pages/CatalogueItemPage.tsx
@@ -1,4 +1,10 @@
-import { CalendarOutlined, EnvironmentOutlined } from '@ant-design/icons'
+/* eslint-disable unicorn/no-null */
+import {
+	CalendarOutlined,
+	EnvironmentOutlined,
+	TagsOutlined,
+	TeamOutlined
+} from '@ant-design/icons'
 import { Skeleton, Tabs } from 'antd'
 import CatalogueItemData from 'components/CatalogueItemData'
 import CatalogueItemLinks from 'components/CatalogueItemLinks'
@@ -16,9 +22,7 @@ const defaultFilters = {
 	countryFilter: [],
 	organizationFilter: [],
 	tagsFilter: [],
-	// eslint-disable-next-line unicorn/no-null
 	dateCreatedFilter: null,
-	// eslint-disable-next-line unicorn/no-null
 	dateUpdatedFilter: null,
 	searchValue: ''
 }
@@ -88,7 +92,6 @@ const CatalogueItemPage = () => {
 		'date-modified': dateModified,
 		'year-period': yearPeriod,
 		'country-region': countryRegion,
-		'card-type': cardType,
 		tags
 	} = catalogueItem
 
@@ -130,10 +133,16 @@ const CatalogueItemPage = () => {
 					{name} {yearPeriodTitle}
 				</span>
 				<div className='mt-2 flex flex-row gap-10 text-sm'>
-					<span>Country/Region: {countryRegion ?? '-'}</span>
-					<span>Date Created: {dateAdded}</span>
-					{dateModified ? <span>Date Updated: {dateModified}</span> : undefined}
-					<span>Type: {cardType}</span>
+					<span>
+						<EnvironmentOutlined />{' '}
+						{countryRegion
+							? `Country/Region: ${formatString(countryRegion)}`
+							: '-'}
+					</span>
+					<span>
+						<CalendarOutlined />{' '}
+						{yearPeriod ? `Year/Period: ${yearPeriod}` : '-'}
+					</span>
 				</div>
 			</div>
 			<div className='flex flex-col md:flex-row'>
@@ -155,7 +164,7 @@ const CatalogueItemPage = () => {
 									<span className='text-xs font-medium text-gray-500'>
 										COUNTRY / REGION
 									</span>
-									<span className='font-medium'>
+									<span className='text-sm font-medium'>
 										{countryRegion ? formatString(countryRegion) : '-'}
 									</span>
 								</div>
@@ -172,7 +181,31 @@ const CatalogueItemPage = () => {
 									<span className='text-xs font-medium text-gray-500'>
 										YEAR / PERIOD
 									</span>
-									<span className='font-medium'>{yearPeriod ?? '-'}</span>
+									<span className='text-sm font-medium'>
+										{yearPeriod ?? '-'}
+									</span>
+								</div>
+							</div>
+							<div className='align-center flex flex-row gap-3'>
+								<TeamOutlined
+									style={{
+										color: '#6b7280',
+										fontSize: '24px',
+										margin: 'auto 0'
+									}}
+								/>
+								<div className='flex flex-col'>
+									<span className='text-xs font-medium text-gray-500'>
+										ORGANIZATION
+									</span>
+									<a
+										href={organization.url}
+										target='_blank'
+										rel='noreferrer'
+										className='text-sm font-medium hover:underline'
+									>
+										{organization.name}
+									</a>
 								</div>
 							</div>
 							<div className='align-center flex flex-row gap-3'>
@@ -187,7 +220,7 @@ const CatalogueItemPage = () => {
 									<span className='text-xs font-medium text-gray-500'>
 										DATE CREATED
 									</span>
-									<span className='font-medium'>
+									<span className='text-sm font-medium'>
 										{dayjs(dateAdded).format('MMM DD, YYYY')}
 									</span>
 								</div>
@@ -197,7 +230,7 @@ const CatalogueItemPage = () => {
 									<span className='text-xs font-medium text-gray-500'>
 										DATE UPDATED
 									</span>
-									<span className='font-medium'>
+									<span className='text-sm font-medium'>
 										{dayjs(dateModified).format('MMM DD, YYYY')}
 									</span>
 								</div>
@@ -205,7 +238,10 @@ const CatalogueItemPage = () => {
 						</div>
 					</div>
 					<div className='rounded bg-gray-50 p-5'>
-						<span className='text-sm font-semibold'>Tags</span>
+						<span className='text-sm font-semibold'>
+							<TagsOutlined style={{ marginRight: '8px' }} />
+							Tags
+						</span>
 						<div className='flex flex-wrap gap-3 py-3'>
 							{tags?.map(tag => (
 								<Tag key={tag} value={tag} onFilterClick={onTagClick}>

--- a/src/pages/CatalogueItemPage.tsx
+++ b/src/pages/CatalogueItemPage.tsx
@@ -1,5 +1,7 @@
 import { CalendarOutlined, EnvironmentOutlined } from '@ant-design/icons'
-import { Skeleton } from 'antd'
+import { Skeleton, Tabs } from 'antd'
+import CatalogueItemData from 'components/CatalogueItemData'
+import CatalogueItemOverview from 'components/CatalogueItemOverview'
 import { useCatalogueItemContext } from 'context/CatalogueItemContext'
 import { useFilterContext } from 'context/FilterContext'
 import dayjs from 'dayjs'
@@ -80,58 +82,37 @@ const CatalogueItemPage = () => {
 
 	const {
 		name,
-		description,
 		organization,
 		'date-added': dateAdded,
 		'date-modified': dateModified,
 		'year-period': yearPeriod,
 		'country-region': countryRegion,
-		'evaluation-metrics': evaluationMetric,
 		'card-type': cardType,
-		links,
 		tags
 	} = catalogueItem
-
-	const evaluationMetricSection = evaluationMetric?.map(evalItem => {
-		const { metric, link } = evalItem
-		// Metric and link can be undefined so there is a need to check if it exists
-		const metricItem = metric && (
-			<>
-				{metric['metric-type']} ({metric.value})
-			</>
-		)
-		const linkItem = link && (
-			<a
-				href={link.url}
-				target='_blank'
-				rel='noreferrer'
-				className='hover:underline'
-			>
-				{link.description}
-			</a>
-		)
-		if (metric && link) {
-			return (
-				<div className='' key={metric['metric-type']}>
-					{metricItem}
-					<br />
-					{linkItem}
-				</div>
-			)
-		}
-		if (metric) {
-			return <div key={metric['metric-type']}>{metricItem}</div>
-		}
-		if (link) {
-			return <div key={link.url}>{linkItem}</div>
-		}
-		return '-'
-	})
 
 	let yearPeriodTitle
 	if (yearPeriod) {
 		yearPeriodTitle = <span>({yearPeriod})</span>
 	}
+
+	const tabItems = [
+		{
+			key: '1',
+			label: 'Overview',
+			children: <CatalogueItemOverview catalogueItem={catalogueItem} />
+		},
+		{
+			key: '2',
+			label: 'Data',
+			children: <CatalogueItemData catalogueItem={catalogueItem} />
+		},
+		{
+			key: '3',
+			label: 'Related Links',
+			children: '<List of related links>'
+		}
+	]
 
 	return (
 		<div className='min-h-[calc(100vh_-_3rem)] bg-white'>
@@ -156,63 +137,12 @@ const CatalogueItemPage = () => {
 			</div>
 			<div className='flex flex-col md:flex-row'>
 				<div className='flex w-full flex-col gap-4 p-10 text-cloud-burst md:w-2/3'>
-					<section className='mb-5'>
-						<span className='text-sm font-semibold'>Overview</span>
-						<p className='mx-5 mt-3 text-gray-600'>{description}</p>
-					</section>
-					<section>
-						<h2 className='mt-5 text-sm font-semibold'>Properties</h2>
-						<table className='mt-3 mb-5 border-separate border-spacing-x-5 border-spacing-y-2'>
-							<tbody>
-								<tr>
-									<td className='font-medium'>Country/Region</td>
-									<td className='text-gray-600'>{countryRegion ?? '-'}</td>
-								</tr>
-								<tr>
-									<td className='font-medium'>Year/Period</td>
-									<td className='text-gray-600'>{yearPeriod ?? '-'}</td>
-								</tr>
-								{evaluationMetric !== undefined && (
-									<tr>
-										<td className='align-top font-medium'>Evaluation Metric</td>
-										<td>
-											<div className='flex flex-col gap-3 text-gray-600'>
-												{evaluationMetricSection}
-											</div>
-										</td>
-									</tr>
-								)}
-							</tbody>
-						</table>
-					</section>
-					<section>
-						<h2 className='mt-5 mb-3 text-sm font-semibold'>Data</h2>
-						<div className='mb-5 grid-cols-1 divide-y divide-gray-100'>
-							{links.map(link => (
-								<div
-									key={link.url}
-									className='align-center flex flex-col rounded p-5'
-								>
-									<span className='text-xs text-gray-600'>{link.type}</span>
-									<a
-										href={link.url}
-										key={`${link.description}`}
-										target='_blank'
-										rel='noreferrer'
-										className='w-full hover:underline'
-									>
-										{link.description}
-									</a>
-								</div>
-							))}
-						</div>
-					</section>
+					<Tabs defaultActiveKey='1' items={tabItems} />
 				</div>
 				<div className='flex w-full flex-col gap-5 p-10 text-cloud-burst md:w-1/3'>
 					<div className='rounded bg-gray-50 p-6'>
-						<span className='font-semibold'>Details</span>
 						<div className='flex flex-col gap-5'>
-							<div className='align-center mt-5 flex flex-row gap-3'>
+							<div className='align-center flex flex-row gap-3'>
 								<EnvironmentOutlined
 									style={{
 										color: '#6b7280',

--- a/src/pages/CatalogueItemPage.tsx
+++ b/src/pages/CatalogueItemPage.tsx
@@ -1,13 +1,14 @@
 import { CalendarOutlined, EnvironmentOutlined } from '@ant-design/icons'
 import { Skeleton, Tabs } from 'antd'
 import CatalogueItemData from 'components/CatalogueItemData'
+import CatalogueItemLinks from 'components/CatalogueItemLinks'
 import CatalogueItemOverview from 'components/CatalogueItemOverview'
 import { useCatalogueItemContext } from 'context/CatalogueItemContext'
 import { useFilterContext } from 'context/FilterContext'
 import dayjs from 'dayjs'
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import formatString from 'utils/String.util'
+import { formatString } from 'utils/String.util'
 import Tag from '../components/Tag'
 import type { CatalogueItemType } from '../types/CatalogueItem.type'
 
@@ -110,7 +111,7 @@ const CatalogueItemPage = () => {
 		{
 			key: '3',
 			label: 'Related Links',
-			children: '<List of related links>'
+			children: <CatalogueItemLinks catalogueItem={catalogueItem} />
 		}
 	]
 

--- a/src/utils/Filters.util.ts
+++ b/src/utils/Filters.util.ts
@@ -9,7 +9,7 @@ import type {
 	FilterOption,
 	FiltersType
 } from 'types/SearchFilters.type'
-import formatString from './String.util'
+import { formatString } from './String.util'
 
 export const getCountryOptions = (
 	catalogueItems: CatalogueItemType[]

--- a/src/utils/Filters.util.ts
+++ b/src/utils/Filters.util.ts
@@ -9,6 +9,7 @@ import type {
 	FilterOption,
 	FiltersType
 } from 'types/SearchFilters.type'
+import formatString from './String.util'
 
 export const getCountryOptions = (
 	catalogueItems: CatalogueItemType[]
@@ -29,9 +30,7 @@ export const getCountryOptions = (
 
 			acc.push({
 				catalogueIds: [id],
-				label: countryRegion
-					.replace('-', ' ')
-					.replace(/\b\w/g, l => l.toUpperCase()),
+				label: formatString(countryRegion),
 				value: countryRegion
 			})
 			return acc

--- a/src/utils/String.util.ts
+++ b/src/utils/String.util.ts
@@ -1,10 +1,10 @@
-const formatString = (str: string) =>
+export const formatString = (str: string) =>
 	str.replaceAll('-', ' ').replaceAll(/\b\w/g, l => l.toUpperCase())
-
-export default formatString
 
 export const getFileFormat = (str: string, separator: string) => {
 	const index = str.lastIndexOf(separator)
+
+	// eslint-disable-next-line @typescript-eslint/no-magic-numbers
 	if (index === -1) {
 		return ''
 	}

--- a/src/utils/String.util.ts
+++ b/src/utils/String.util.ts
@@ -1,0 +1,4 @@
+const formatString = (str: string) =>
+	str.replaceAll('-', ' ').replaceAll(/\b\w/g, l => l.toUpperCase())
+
+export default formatString

--- a/src/utils/String.util.ts
+++ b/src/utils/String.util.ts
@@ -2,3 +2,11 @@ const formatString = (str: string) =>
 	str.replaceAll('-', ' ').replaceAll(/\b\w/g, l => l.toUpperCase())
 
 export default formatString
+
+export const getFileFormat = (str: string, separator: string) => {
+	const index = str.lastIndexOf(separator)
+	if (index === -1) {
+		return ''
+	}
+	return str.slice(index + separator.length)
+}


### PR DESCRIPTION
This PR includes:
- updating the content to show tabs for overview, data, and related links
- updating yaml files to add links for research-paper, limitations, and training dataset
- icons using @ant-design/icons
- fix formatting of text

For the data tab, I separated the training dataset, raw dataset, and dataset. For training datasets and raw datasets, I added a copy link button that copies the link to clipboard. For dataset, I just listed down the link. Reason for this is because that for raw datasets, they can just copy the link and paste it in their viz tools. For datasets that are not raw, they still need to download the data.

Not entirely sure if that should be the case for training datasets? Should we remove the copy link button for them?

Videos:

https://user-images.githubusercontent.com/26348221/228707001-b6cb6396-4faf-4eeb-bf4b-f0e3927941dd.mov

https://user-images.githubusercontent.com/26348221/228707037-fbbc6299-3802-470f-b63a-1583b26d9893.mov

https://user-images.githubusercontent.com/26348221/228707067-9216e606-f611-4c99-bafc-0cc46ea13fb1.mov

https://user-images.githubusercontent.com/26348221/228707101-adc08121-470c-4a18-9597-f750a6cb6aeb.mov

