### PR TITLE
Fix search styling, add allowClear feature, and bug fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,8 @@ export default function App(): ReactElement {
 				theme={{
 					token: {
 						colorPrimary: '#24295c',
-						colorPrimaryBg: '#d3d4de'
+						colorPrimaryBg: '#d3d4de',
+						lineHeightLG: 1.39
 					}
 				}}
 			>

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,5 +1,9 @@
-import { CalendarOutlined, EnvironmentOutlined } from '@ant-design/icons'
-import { AutoComplete, Input } from 'antd'
+import {
+	CalendarOutlined,
+	EnvironmentOutlined,
+	SearchOutlined
+} from '@ant-design/icons'
+import { AutoComplete, Button, Input } from 'antd'
 import { useCatalogueItemContext } from 'context/CatalogueItemContext'
 import { useSearchContext } from 'context/SearchContext'
 import { useNavigate } from 'react-router-dom'
@@ -90,12 +94,17 @@ const SearchInput = ({ onSearchBtnClick, path, inputWidth }: Props) => {
 			onSearch={onSearch}
 			onSelect={onSelect}
 			defaultValue={searchInput}
-			style={{ width: inputWidth }}
+			style={{ width: inputWidth, letterSpacing: '-0.025em' }}
 		>
 			<Input.Search
 				size='large'
 				placeholder='Search for a dataset or a model'
 				onSearch={onSearchBtnClick}
+				enterButton={
+					<Button style={{ backgroundColor: 'white' }} size='large'>
+						<SearchOutlined color='#24295c' />
+					</Button>
+				}
 			/>
 		</AutoComplete>
 	)

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -5,13 +5,20 @@ import {
 } from '@ant-design/icons'
 import { AutoComplete, Button, Input } from 'antd'
 import { useCatalogueItemContext } from 'context/CatalogueItemContext'
+import { useFilterContext } from 'context/FilterContext'
 import { useSearchContext } from 'context/SearchContext'
 import { useNavigate } from 'react-router-dom'
 import type { SearchOptionsType } from 'types/SearchFilters.type'
 import { formatString } from 'utils/String.util'
 
 interface Props {
-	onSearchBtnClick: (searchValue: string) => void
+	onSearchBtnClick: (
+		searchValue: string,
+		event?:
+			| React.ChangeEvent<HTMLInputElement>
+			| React.KeyboardEvent<HTMLInputElement>
+			| React.MouseEvent<HTMLElement, MouseEvent> // eslint-disable-line @typescript-eslint/no-unnecessary-type-arguments
+	) => void
 	path: string
 	inputWidth?: string
 }
@@ -23,9 +30,10 @@ const SearchInput = ({ onSearchBtnClick, path, inputWidth }: Props) => {
 	const { filteredCatalogueItems } = useCatalogueItemContext()
 	const { searchInput, setSearchInput, searchOptions, setSearchOptions } =
 		useSearchContext()
+	const { setFilters } = useFilterContext()
 
 	const onSearch = (searchValue: string) => {
-		if (searchValue.length === 0) {
+		if (searchValue.length < 3) {
 			setSearchOptions([])
 			return
 		}
@@ -84,7 +92,9 @@ const SearchInput = ({ onSearchBtnClick, path, inputWidth }: Props) => {
 		setSearchInput(searchValue)
 	}
 
-	const onSelect = (_: string, option: SearchOptionsType) => {
+	const onSelect = (title: string, option: SearchOptionsType) => {
+		setFilters(prevFilters => ({ ...prevFilters, searchValue: title }))
+		setSearchInput(title)
 		navigate(`${path}${option.data.id}`)
 	}
 
@@ -100,6 +110,7 @@ const SearchInput = ({ onSearchBtnClick, path, inputWidth }: Props) => {
 				size='large'
 				placeholder='Search for a dataset or a model'
 				onSearch={onSearchBtnClick}
+				allowClear
 				enterButton={
 					<Button style={{ backgroundColor: 'white' }} size='large'>
 						<SearchOutlined color='#24295c' />

--- a/src/index.css
+++ b/src/index.css
@@ -43,10 +43,9 @@
 		--tw-ring-color: transparent;
 	}
 
-	/* TODO: Fix ant design styling for search button and input */
 	input[type='search'] {
 		border-color: #e5e7eb;
-		border-radius: 8px;
+		border-radius: 6px;
 	}
 
 	svg {

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -15,8 +15,18 @@ const LandingPage = () => {
 		setIsFiltersLoading
 	} = useFilterContext()
 
-	const onSearchBtnClick = (searchValue: string) => {
+	const onSearchBtnClick = (
+		searchValue: string,
+		event?:
+			| React.ChangeEvent<HTMLInputElement>
+			| React.KeyboardEvent<HTMLInputElement>
+			| React.MouseEvent<HTMLElement, MouseEvent> // eslint-disable-line @typescript-eslint/no-unnecessary-type-arguments
+	) => {
 		setFilters(prevFilters => ({ ...prevFilters, searchValue }))
+
+		if (event?.type === 'click' && event.currentTarget.localName === 'input')
+			return
+
 		navigate('catalogue')
 	}
 

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -63,7 +63,7 @@ const LandingPage = () => {
 						Browse our catalogue of models and datasets to gain access to code,
 						documentation, and pre-processed datasets that fit to your needs
 					</span>
-					<div className='my-5 w-2/3 rounded-md bg-white'>
+					<div className='my-5 flex w-2/3 flex-row'>
 						<SearchInput
 							onSearchBtnClick={onSearchBtnClick}
 							path='catalogue/'


### PR DESCRIPTION
This PR includes:
- updating ant design theme to fix search styling
- adding allowClear feature for search
- fixing bug on unfiltered items when a suggestion is clicked. (e.g. if I search for a model in the landing page and click on a search suggestion, then navigate to the catalogue page, it still shows me all items even i have entered a search input)

Screenshots:

<img width="1440" alt="Screenshot 2023-03-30 at 2 36 06 PM" src="https://user-images.githubusercontent.com/26348221/228750182-56548187-c545-438d-a89e-8bf9fd410df5.png">

<img width="1440" alt="Screenshot 2023-03-30 at 2 36 14 PM" src="https://user-images.githubusercontent.com/26348221/228750208-f98f3aad-deaf-4d84-8133-d49378c3ca39.png">