### PR TITLE
Fix misc search bugs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ export default function App(): ReactElement {
 					token: {
 						colorPrimary: '#24295c',
 						colorPrimaryBg: '#d3d4de',
+						colorLinkHover: '#24295c',
 						lineHeightLG: 1.39
 					}
 				}}

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -27,7 +27,7 @@ const MAX_OPTIONS = 10
 
 const SearchInput = ({ onSearchBtnClick, path, inputWidth }: Props) => {
 	const navigate = useNavigate()
-	const { filteredCatalogueItems } = useCatalogueItemContext()
+	const { catalogueItems } = useCatalogueItemContext()
 	const { searchInput, setSearchInput, searchOptions, setSearchOptions } =
 		useSearchContext()
 	const { setFilters } = useFilterContext()
@@ -38,7 +38,7 @@ const SearchInput = ({ onSearchBtnClick, path, inputWidth }: Props) => {
 			return
 		}
 
-		const options = filteredCatalogueItems
+		const options = catalogueItems
 			.filter(item =>
 				item.name.toLowerCase().includes(searchValue.toLowerCase())
 			)

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -95,6 +95,7 @@ const SearchInput = ({ onSearchBtnClick, path, inputWidth }: Props) => {
 	const onSelect = (title: string, option: SearchOptionsType) => {
 		setFilters(prevFilters => ({ ...prevFilters, searchValue: title }))
 		setSearchInput(title)
+		setSearchOptions([option])
 		navigate(`${path}${option.data.id}`)
 	}
 

--- a/src/pages/CatalogueItemPage.tsx
+++ b/src/pages/CatalogueItemPage.tsx
@@ -11,6 +11,7 @@ import CatalogueItemLinks from 'components/CatalogueItemLinks'
 import CatalogueItemOverview from 'components/CatalogueItemOverview'
 import { useCatalogueItemContext } from 'context/CatalogueItemContext'
 import { useFilterContext } from 'context/FilterContext'
+import { useSearchContext } from 'context/SearchContext'
 import dayjs from 'dayjs'
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -29,7 +30,8 @@ const defaultFilters = {
 
 const CatalogueItemPage = () => {
 	const { id } = useParams()
-	const { setFilters } = useFilterContext()
+	const { setSearchInput } = useSearchContext()
+	const { setFilters, setIsFiltersLoading } = useFilterContext()
 	const navigate = useNavigate()
 
 	const [isLoading, setIsLoading] = useState(true)
@@ -55,6 +57,8 @@ const CatalogueItemPage = () => {
 	}, [catalogueItemContext, id])
 
 	const onTagClick = (value: string) => {
+		setIsFiltersLoading(true)
+		setSearchInput('')
 		setFilters({
 			...defaultFilters,
 			tagsFilter: [value]

--- a/src/pages/CataloguePage.tsx
+++ b/src/pages/CataloguePage.tsx
@@ -3,12 +3,14 @@ import CatalogueItemCard from 'components/CatalogueItemCard'
 import SearchInput from 'components/SearchInput'
 import { useCatalogueItemContext } from 'context/CatalogueItemContext'
 import { useFilterContext } from 'context/FilterContext'
+import { useSearchContext } from 'context/SearchContext'
 import type { DateFilterType } from 'types/SearchFilters.type'
 import CatalogueHeroImg from '../assets/catalogue-hero-bg.jpg'
 
 const { RangePicker } = DatePicker
 
 const CataloguePage = () => {
+	const { setSearchInput } = useSearchContext()
 	const { filteredCatalogueItems, isLoading: isCatalogueItemsLoading } =
 		useCatalogueItemContext()
 	const {
@@ -42,8 +44,18 @@ const CataloguePage = () => {
 		setFilters(prevFilters => ({ ...prevFilters, dateUpdatedFilter: dates }))
 	}
 
-	const onSearchBtnClick = (searchValue: string) => {
+	const onSearchBtnClick = (
+		searchValue: string,
+		event?:
+			| React.ChangeEvent<HTMLInputElement>
+			| React.KeyboardEvent<HTMLInputElement>
+			| React.MouseEvent<HTMLElement, MouseEvent> // eslint-disable-line @typescript-eslint/no-unnecessary-type-arguments
+	) => {
 		setFilters(prevFilters => ({ ...prevFilters, searchValue }))
+
+		if (event?.type === 'click' && event.currentTarget.localName === 'input') {
+			setSearchInput('')
+		}
 	}
 
 	if (isLoading) {

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,12 +1,14 @@
 import { Skeleton } from 'antd'
 import SearchInput from 'components/SearchInput'
 import { useFilterContext } from 'context/FilterContext'
+import { useSearchContext } from 'context/SearchContext'
 import { useNavigate } from 'react-router-dom'
 import LandingHeroImg from '../assets/landing-hero-bg.jpg'
 import Tag from '../components/Tag'
 
 const LandingPage = () => {
 	const navigate = useNavigate()
+	const { setSearchInput } = useSearchContext()
 	const {
 		isFilterOptionsLoading,
 		countries,
@@ -24,8 +26,10 @@ const LandingPage = () => {
 	) => {
 		setFilters(prevFilters => ({ ...prevFilters, searchValue }))
 
-		if (event?.type === 'click' && event.currentTarget.localName === 'input')
+		if (event?.type === 'click' && event.currentTarget.localName === 'input') {
+			setSearchInput('')
 			return
+		}
 
 		navigate('catalogue')
 	}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -6,6 +6,17 @@ import { useNavigate } from 'react-router-dom'
 import LandingHeroImg from '../assets/landing-hero-bg.jpg'
 import Tag from '../components/Tag'
 
+const defaultFilters = {
+	countryFilter: [],
+	organizationFilter: [],
+	tagsFilter: [],
+	// eslint-disable-next-line unicorn/no-null
+	dateCreatedFilter: null,
+	// eslint-disable-next-line unicorn/no-null
+	dateUpdatedFilter: null,
+	searchValue: ''
+}
+
 const LandingPage = () => {
 	const navigate = useNavigate()
 	const { setSearchInput } = useSearchContext()
@@ -24,7 +35,7 @@ const LandingPage = () => {
 			| React.KeyboardEvent<HTMLInputElement>
 			| React.MouseEvent<HTMLElement, MouseEvent> // eslint-disable-line @typescript-eslint/no-unnecessary-type-arguments
 	) => {
-		setFilters(prevFilters => ({ ...prevFilters, searchValue }))
+		setFilters({ ...defaultFilters, searchValue })
 
 		if (event?.type === 'click' && event.currentTarget.localName === 'input') {
 			setSearchInput('')
@@ -32,17 +43,6 @@ const LandingPage = () => {
 		}
 
 		navigate('catalogue')
-	}
-
-	const defaultFilters = {
-		countryFilter: [],
-		organizationFilter: [],
-		tagsFilter: [],
-		// eslint-disable-next-line unicorn/no-null
-		dateCreatedFilter: null,
-		// eslint-disable-next-line unicorn/no-null
-		dateUpdatedFilter: null,
-		searchValue: ''
 	}
 
 	const onCountryClick = (countryValue: string) => {

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -56,6 +56,7 @@ const LandingPage = () => {
 
 	const onTagClick = (tagValue: string) => {
 		setIsFiltersLoading(true)
+		setSearchInput('')
 		setFilters({ ...defaultFilters, tagsFilter: [tagValue] })
 		navigate('catalogue')
 	}


### PR DESCRIPTION
This PR fixes:
- When I go to the catalogue page and enter a search term, then clear it, and then navigate to the landing page, the search term is still showing there in the search bar.
- Search against all catalogue items rather than filtered ones.
- When clicking on a tag in the landing page and catalogue item page - the search input is not being cleared out.
- For search and filters in the landing page, reset all filters to start fresh. 
- If I click on the landing page and I click on an entry and go back to landing page, I still get search suggestions from all.
- Link color in catalogue item page is not the primary color.