### PR TITLE
Fix/remove gdrive download restriction

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ name: Deploy-GH-Pages
 on:
   push:
     branches: [main]
-# TODO: Add GSTORAGE_API_KEY to env in transform catalog
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy-GH-Pages
 on:
   push:
     branches: [main]
-
+# TODO: Add GSTORAGE_API_KEY to env in transform catalog
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -35,6 +35,8 @@ jobs:
 
       - name: Merge catalog entries
         run: python scripts/transform_catalog.py
+        env:
+          GSTORAGE_API_KEY: ${{ secrets.GSTORAGE_API_KEY }}
 
       - name: Build project
         run: pnpm build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Merge catalog entries
         run: python scripts/transform_catalog.py
+        env:
+          GSTORAGE_API_KEY: ${{ secrets.GSTORAGE_API_KEY }}
 
       - name: Validate format
         run: pnpm run-p lint

--- a/scripts/transform_catalog.py
+++ b/scripts/transform_catalog.py
@@ -13,7 +13,7 @@ OUTPUT_PATH = "./public/api/data/catalog.json"
 def transform_links(links):
     new_links = []
     for link in links:
-        new_link = transform_dataset_file_link(link)
+        new_link = transform_dataset_file_link(link, use_gstorage=True)
         new_links.append(new_link)
     return new_links
 


### PR DESCRIPTION
* Use googleapis google storage api  link to download gdrive data without virus check/warning.