### PR TITLE
Update year filter to allow empty start or end years

### DIFF
--- a/catalog/airquality-thailand-model.yml
+++ b/catalog/airquality-thailand-model.yml
@@ -10,7 +10,7 @@ tags:
   - thailand
   - machine-learning
 country-region: thailand
-year-period: 2021
+year-period: 2020-2023
 evaluation-metrics:
   - link:
       description: 'Manuscript - see Section 3.3 Evaluation and Metrics'

--- a/src/pages/CataloguePage.tsx
+++ b/src/pages/CataloguePage.tsx
@@ -123,6 +123,7 @@ const CataloguePage = () => {
 								onChange={onYearChange}
 								defaultValue={filters.yearFilter}
 								picker='year'
+								allowEmpty={[true, true]}
 							/>
 						</div>
 

--- a/src/utils/Filters.util.ts
+++ b/src/utils/Filters.util.ts
@@ -130,6 +130,20 @@ export const getIntersectionOfIds = (
 	)
 }
 
+const getYearsFromPeriod = (yearPeriod: string): number[] => {
+	const [startYear, endYear] = yearPeriod
+		.toString()
+		.split('-')
+		.map(year => parseInt(year))
+
+	if (!endYear) {
+		return [startYear]
+	}
+
+	const length = endYear - startYear + 1
+	return Array.from({ length }, (_, index) => startYear + index)
+}
+
 export const getCatalogueIdsByYear = (
 	yearFilter: DateFilterType,
 	catalogueItems: CatalogueItemType[]
@@ -141,7 +155,7 @@ export const getCatalogueIdsByYear = (
 	const filteredItems = catalogueItems.filter(item => {
 		if (!item['year-period']) return false
 
-		const years = item['year-period'].toString().split('-')
+		const years = getYearsFromPeriod(item['year-period'])
 
 		for (const year of years) {
 			const currentDate = dayjs(`${year}-01-01`)

--- a/src/utils/Filters.util.ts
+++ b/src/utils/Filters.util.ts
@@ -134,7 +134,7 @@ const getYearsFromPeriod = (yearPeriod: string): number[] => {
 	const [startYear, endYear] = yearPeriod
 		.toString()
 		.split('-')
-		.map(year => parseInt(year))
+		.map(year => Number.parseInt(year, 10))
 
 	if (!endYear) {
 		return [startYear]

--- a/src/utils/Filters.util.ts
+++ b/src/utils/Filters.util.ts
@@ -2,6 +2,8 @@
 /* eslint-disable unicorn/no-null */
 
 import dayjs from 'dayjs'
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
 import type { CatalogueItemType } from 'types/CatalogueItem.type'
 import type {
 	DateFilterType,
@@ -9,6 +11,9 @@ import type {
 	FiltersType
 } from 'types/SearchFilters.type'
 import { formatString } from './String.util'
+
+dayjs.extend(isSameOrAfter)
+dayjs.extend(isSameOrBefore)
 
 export const getCountryOptions = (
 	catalogueItems: CatalogueItemType[]
@@ -143,9 +148,27 @@ export const getCatalogueIdsByYear = (
 			const startYear = yearFilter[0]?.year()
 			const endYear = yearFilter[1]?.year()
 
-			if (!startYear || !endYear) return false
+			if (!startYear && !endYear) return false
 
 			if (
+				startYear &&
+				!endYear &&
+				currentDate.isSameOrAfter(`${startYear}-01-01`, 'year')
+			) {
+				return true
+			}
+
+			if (
+				endYear &&
+				!startYear &&
+				currentDate.isSameOrBefore(`${endYear}-01-01`, 'year')
+			) {
+				return true
+			}
+
+			if (
+				startYear &&
+				endYear &&
 				currentDate.isBetween(
 					`${startYear}-01-01`,
 					`${endYear}-01-01`,


### PR DESCRIPTION
This PR includes:
- updating the filter logic to accommodate multiple years (ex. of 'year-period' = 2020-2023)
- allow empty start or end years
   - if startYear is filled and endYear is empty, the results will be filtered to items that start with the startYear
   - if endYear is filled and startYear is empty, the results will be filtered to items that end with the endYear

Screenshots:
<img width="1440" alt="Screenshot 2023-04-11 at 11 48 16 AM" src="https://user-images.githubusercontent.com/26348221/231051823-21b170c4-7782-49d7-b267-67f090784f78.png">

<img width="1440" alt="Screenshot 2023-04-11 at 11 48 26 AM" src="https://user-images.githubusercontent.com/26348221/231051843-b3b26f57-6b6e-4379-a2ae-4787c10ddad8.png">

<img width="1440" alt="Screenshot 2023-04-11 at 11 49 23 AM" src="https://user-images.githubusercontent.com/26348221/231051886-ea7ed819-7545-49aa-8034-4ecddc836050.png">

<img width="1440" alt="Screenshot 2023-04-11 at 11 49 43 AM" src="https://user-images.githubusercontent.com/26348221/231051934-74b9a9ad-82b5-499d-99a5-d3142787f3dd.png">

