### PR TITLE
Create 404 page for nonexistent links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { ConfigProvider } from 'antd'
 import Header from 'components/Header'
+import NotFound from 'components/NotFound'
 import { CatalogueItemProvider } from 'context/CatalogueItemContext'
 import { FilterProvider } from 'context/FilterContext'
 import { SearchProvider } from 'context/SearchContext'
@@ -35,7 +36,9 @@ export default function App(): ReactElement {
 								<Route path={`${HOME_PATH}/catalogue`}>
 									<Route index element={<CataloguePage />} />
 									<Route path=':id' element={<CatalogueItemPage />} />
+									<Route path='*' element={<NotFound />} />
 								</Route>
+								<Route path='*' element={<NotFound />} />
 							</Routes>
 						</SearchProvider>
 					</FilterProvider>

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -1,0 +1,21 @@
+import { FrownOutlined } from '@ant-design/icons'
+import { Link } from 'react-router-dom'
+import HOME_PATH from '../constants'
+
+const NotFound = () => (
+	<div className='flex h-[calc(100vh_-_3rem)] flex-col items-center justify-center gap-5 border-t border-gray-200 bg-white text-cloud-burst'>
+		<FrownOutlined style={{ color: '#24295C', fontSize: '100px' }} />
+		<h1 className='text-3xl font-bold'>Page Not Found!</h1>
+		<p className='mx-8 text-center'>
+			Sorry, the page you are looking for could not be found.
+		</p>
+		<Link
+			to={`${HOME_PATH}/`}
+			className='rounded bg-cloud-burst p-2 text-left tracking-tight text-white hover:bg-opacity-95'
+		>
+			Go to homepage
+		</Link>
+	</div>
+)
+
+export default NotFound

--- a/src/pages/CatalogueItemPage.tsx
+++ b/src/pages/CatalogueItemPage.tsx
@@ -9,6 +9,7 @@ import { Skeleton, Tabs } from 'antd'
 import CatalogueItemData from 'components/CatalogueItemData'
 import CatalogueItemLinks from 'components/CatalogueItemLinks'
 import CatalogueItemOverview from 'components/CatalogueItemOverview'
+import NotFound from 'components/NotFound'
 import { useCatalogueItemContext } from 'context/CatalogueItemContext'
 import { useFilterContext } from 'context/FilterContext'
 import { useSearchContext } from 'context/SearchContext'
@@ -81,11 +82,7 @@ const CatalogueItemPage = () => {
 	}
 
 	if (!catalogueItem) {
-		return (
-			<div className='h-[calc(100vh_-_3rem)] bg-white text-cloud-burst'>
-				error
-			</div>
-		)
+		return <NotFound />
 	}
 
 	const {


### PR DESCRIPTION
This PR includes creating a 404 page to let the user know that the link doesn't exist rather than showing a blank page. The 404 page is being handled via react-router.

See issue https://github.com/thinkingmachines/unicef-ai4d-research-bank/issues/52

Screenshot:
<img width="1440" alt="Screenshot 2023-04-26 at 10 37 05 PM" src="https://user-images.githubusercontent.com/26348221/234611845-95c092e7-de80-4e72-b597-5dca2ea12526.png">
