### PR TITLE
feat: add Pagination, Toggle filter, and Dropdown filter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,11 @@ const theme = {
 		colorPrimaryBg: '#d3d4de',
 		colorLinkHover: '#24295c',
 		lineHeightLG: 1.39
+	},
+	components: {
+		Pagination: {
+			borderRadius: 0
+		}
 	}
 }
 

--- a/src/components/CustomRadio.tsx
+++ b/src/components/CustomRadio.tsx
@@ -1,0 +1,37 @@
+import { Radio } from 'antd'
+import type { ToggleOption } from '../constants/index'
+import { TOGGLE_OPTIONS } from '../constants/index'
+
+interface CustomRadioProps {
+	updateParentOptions: (value: ToggleOption) => void
+}
+
+const CustomRadio = ({ updateParentOptions }: CustomRadioProps) => {
+	const onToggle = (x: ToggleOption) => updateParentOptions(x)
+
+	return (
+		<Radio.Group defaultValue={TOGGLE_OPTIONS.All} buttonStyle='solid'>
+			<Radio.Button
+				value={TOGGLE_OPTIONS.All}
+				style={{ borderRadius: 0 }}
+				onClick={() => onToggle(TOGGLE_OPTIONS.All)}
+			>
+				All
+			</Radio.Button>
+			<Radio.Button
+				value={TOGGLE_OPTIONS.model}
+				onClick={() => onToggle(TOGGLE_OPTIONS.model)}
+			>
+				Models
+			</Radio.Button>
+			<Radio.Button
+				value={TOGGLE_OPTIONS.dataset}
+				onClick={() => onToggle(TOGGLE_OPTIONS.dataset)}
+				style={{ borderRadius: 0 }}
+			>
+				Datasets
+			</Radio.Button>
+		</Radio.Group>
+	)
+}
+export default CustomRadio

--- a/src/components/CustomRadio.tsx
+++ b/src/components/CustomRadio.tsx
@@ -7,7 +7,7 @@ interface CustomRadioProps {
 }
 
 const CustomRadio = ({ updateParentOptions }: CustomRadioProps) => {
-	const onToggle = (x: ToggleOption) => updateParentOptions(x)
+	const onToggle = (value: ToggleOption) => updateParentOptions(value)
 
 	return (
 		<Radio.Group defaultValue={TOGGLE_OPTIONS.All} buttonStyle='solid'>

--- a/src/components/CustomSelect.tsx
+++ b/src/components/CustomSelect.tsx
@@ -1,0 +1,48 @@
+import { Select } from 'antd'
+import type { SelectOption } from '../constants/index'
+import { SELECT_OPTIONS } from '../constants/index'
+import '../css/CustomSelect.css'
+
+interface CustomSelectProps {
+	updateParentOptions: (value: SelectOption) => void
+}
+
+const CustomSelect = ({ updateParentOptions }: CustomSelectProps) => {
+	const onChange = (value: string) => {
+		const selectOptionValue = value as SelectOption
+		updateParentOptions(selectOptionValue)
+	}
+
+	return (
+		<div>
+			<Select
+				defaultValue='None'
+				style={{ width: 150, borderRadius: 0 }}
+				onChange={value => onChange(value)}
+				options={[
+					{
+						value: SELECT_OPTIONS.none,
+						label: 'none'
+					},
+					{
+						value: SELECT_OPTIONS.yearAsc,
+						label: 'Year Ascending'
+					},
+					{
+						value: SELECT_OPTIONS.yearDesc,
+						label: 'Year Descending'
+					},
+					{
+						value: SELECT_OPTIONS.nameAsc,
+						label: 'Name Ascending'
+					},
+					{
+						value: SELECT_OPTIONS.nameDesc,
+						label: 'Name Descending'
+					}
+				]}
+			/>
+		</div>
+	)
+}
+export default CustomSelect

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -12,3 +12,13 @@ export const TOGGLE_OPTIONS = {
 } as const
 
 export type ToggleOption = (typeof TOGGLE_OPTIONS)[keyof typeof TOGGLE_OPTIONS]
+
+export const SELECT_OPTIONS = {
+	none: 'none',
+	nameAsc: 'Name Ascending',
+	nameDesc: 'Name Descending',
+	yearAsc: 'Year Ascending',
+	yearDesc: 'Year Descending'
+} as const
+
+export type SelectOption = (typeof SELECT_OPTIONS)[keyof typeof SELECT_OPTIONS]

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,6 @@
 export default import.meta.env.VITE_HOME_PATH as string
+
+export const PAGE_SIZE = 5
+
 export const CONTRIBUTION_URL =
 	'https://raw.githubusercontent.com/thinkingmachines/unicef-ai4d-research-bank/main/catalog-contribution.md'

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,14 @@
 export default import.meta.env.VITE_HOME_PATH as string
 
-export const PAGE_SIZE = 5
-
 export const CONTRIBUTION_URL =
 	'https://raw.githubusercontent.com/thinkingmachines/unicef-ai4d-research-bank/main/catalog-contribution.md'
+
+export const PAGE_SIZE = 5
+
+export const TOGGLE_OPTIONS = {
+	All: 'All',
+	model: 'model',
+	dataset: 'dataset'
+} as const
+
+export type ToggleOption = (typeof TOGGLE_OPTIONS)[keyof typeof TOGGLE_OPTIONS]

--- a/src/css/CustomSelect.css
+++ b/src/css/CustomSelect.css
@@ -1,0 +1,3 @@
+.ant-select-selector {
+	border-radius: 0 !important;
+}

--- a/src/css/Pagination.css
+++ b/src/css/Pagination.css
@@ -15,5 +15,5 @@
 }
 
 .ant-pagination-total-text {
-	color: #82838d; /* Replace 'red' with your desired font color */
+	color: #82838d;
 }

--- a/src/css/Pagination.css
+++ b/src/css/Pagination.css
@@ -1,0 +1,19 @@
+.ant-pagination-item:not(.ant-pagination-item-active) {
+	border-color: #d9d9d9;
+}
+
+.ant-pagination-prev {
+	border-color: #d9d9d9;
+	border-width: thin;
+	border-style: solid;
+}
+
+.ant-pagination-next {
+	border-color: #d9d9d9;
+	border-width: thin;
+	border-style: solid;
+}
+
+.ant-pagination-total-text {
+	color: #82838d; /* Replace 'red' with your desired font color */
+}

--- a/src/pages/CataloguePage.tsx
+++ b/src/pages/CataloguePage.tsx
@@ -2,6 +2,7 @@ import type { PaginationProps } from 'antd'
 import { DatePicker, Pagination, Select, Skeleton, Space } from 'antd'
 import CatalogueItemCard from 'components/CatalogueItemCard'
 import CustomRadio from 'components/CustomRadio'
+import CustomSelect from 'components/CustomSelect'
 import SearchInput from 'components/SearchInput'
 import { useCatalogueItemContext } from 'context/CatalogueItemContext'
 import { useFilterContext } from 'context/FilterContext'
@@ -9,8 +10,8 @@ import { useSearchContext } from 'context/SearchContext'
 import { useEffect, useState } from 'react'
 import type { DateFilterType } from 'types/SearchFilters.type'
 import CatalogueHeroImg from '../assets/catalogue-hero-bg.jpg'
-import type { ToggleOption } from '../constants/index'
-import { PAGE_SIZE, TOGGLE_OPTIONS } from '../constants/index'
+import type { SelectOption, ToggleOption } from '../constants/index'
+import { PAGE_SIZE, SELECT_OPTIONS, TOGGLE_OPTIONS } from '../constants/index'
 import '../css/Pagination.css'
 
 const { RangePicker } = DatePicker
@@ -19,6 +20,9 @@ const CataloguePage = () => {
 	const [currentPage, setCurrentPage] = useState<number>(1)
 	const [radioOptions, setRadioOptions] = useState<ToggleOption>(
 		TOGGLE_OPTIONS.All
+	)
+	const [selectOptions, setSelectOptions] = useState<SelectOption>(
+		SELECT_OPTIONS.none
 	)
 
 	const { setSearchInput } = useSearchContext()
@@ -80,10 +84,6 @@ const CataloguePage = () => {
 		catalogueItemsSection = <span>No catalogue items available.</span>
 	}
 
-	const updateParentOptions = (value: ToggleOption) => {
-		setRadioOptions(value)
-	}
-
 	useEffect(() => {
 		const toggleFilteredData = filteredCatalogueItems.filter(item => {
 			if (radioOptions === TOGGLE_OPTIONS.model) {
@@ -96,10 +96,44 @@ const CataloguePage = () => {
 			return true
 		})
 
-		setFilteredData(toggleFilteredData)
-	}, [radioOptions, filteredCatalogueItems])
+		const sortedData = [...toggleFilteredData] // Create a copy of toggleFilteredData
 
-	// filter using dropdown
+		if (selectOptions === SELECT_OPTIONS.yearAsc) {
+			sortedData.sort((a, b) => {
+				const yearPeriodA = a['year-period']
+					? Number.parseInt(a['year-period'], 10)
+					: 0
+				const yearPeriodB = b['year-period']
+					? Number.parseInt(b['year-period'], 10)
+					: 0
+
+				return yearPeriodA - yearPeriodB
+			})
+		}
+
+		if (selectOptions === SELECT_OPTIONS.yearDesc) {
+			sortedData.sort((a, b) => {
+				const yearPeriodA = a['year-period']
+					? Number.parseInt(a['year-period'], 10)
+					: 0
+				const yearPeriodB = b['year-period']
+					? Number.parseInt(b['year-period'], 10)
+					: 0
+
+				return yearPeriodB - yearPeriodA
+			})
+		}
+
+		if (selectOptions === SELECT_OPTIONS.nameAsc) {
+			sortedData.sort((a, b) => a.name.localeCompare(b.name))
+		}
+
+		if (selectOptions === SELECT_OPTIONS.nameDesc) {
+			sortedData.sort((a, b) => b.name.localeCompare(a.name))
+		}
+
+		setFilteredData(sortedData)
+	}, [radioOptions, filteredCatalogueItems, selectOptions])
 
 	const startIndex = (currentPage - 1) * PAGE_SIZE
 	const endIndex = startIndex + PAGE_SIZE
@@ -205,10 +239,19 @@ const CataloguePage = () => {
 					</div>
 					<div className='my-5 flex w-full flex-col md:my-0 md:w-2/3'>
 						<div className='flex'>
-							<div className='bg-sky-200'>
-								<CustomRadio updateParentOptions={updateParentOptions} />
+							<CustomRadio
+								updateParentOptions={(value: ToggleOption) => {
+									setRadioOptions(value)
+								}}
+							/>
+							<div className='mx-6 py-1 text-sm font-normal text-[#82838D]'>
+								Sort by:
 							</div>
-							<div className='bg-sky-200'>Dropdown</div>
+							<CustomSelect
+								updateParentOptions={(value: SelectOption) => {
+									setSelectOptions(value)
+								}}
+							/>
 						</div>
 
 						<div className='my-3  text-cloud-burst'>

--- a/src/pages/CataloguePage.tsx
+++ b/src/pages/CataloguePage.tsx
@@ -9,11 +9,14 @@ import { useSearchContext } from 'context/SearchContext'
 import { useState } from 'react'
 import type { DateFilterType } from 'types/SearchFilters.type'
 import CatalogueHeroImg from '../assets/catalogue-hero-bg.jpg'
+import { PAGE_SIZE } from '../constants/index'
 import '../css/Pagination.css'
 
 const { RangePicker } = DatePicker
 
 const CataloguePage = () => {
+	const [currentPage, setCurrentPage] = useState<number>(1)
+
 	const { setSearchInput } = useSearchContext()
 	const { filteredCatalogueItems, isLoading: isCatalogueItemsLoading } =
 		useCatalogueItemContext()
@@ -70,6 +73,9 @@ const CataloguePage = () => {
 		catalogueItemsSection = <span>No catalogue items available.</span>
 	}
 
+	const startIndex = (currentPage - 1) * PAGE_SIZE
+	const endIndex = startIndex + PAGE_SIZE
+
 	if (!isLoading && filteredCatalogueItems.length > 0) {
 		catalogueItemsSection = (
 			<>
@@ -79,21 +85,21 @@ const CataloguePage = () => {
 					available
 				</span>
 				<div className='grid grid-cols-1 divide-y divide-gray-100 '>
-					{filteredCatalogueItems.map(catalogueItem => (
-						<CatalogueItemCard
-							key={catalogueItem.id}
-							catalogueItemData={catalogueItem}
-						/>
-					))}
+					{filteredCatalogueItems
+						.slice(startIndex, endIndex)
+						.map(catalogueItem => (
+							<CatalogueItemCard
+								key={catalogueItem.id}
+								catalogueItemData={catalogueItem}
+							/>
+						))}
 				</div>
 			</>
 		)
 	}
 
-	const [current, setCurrent] = useState<number>(3)
-
 	const onChange: PaginationProps['onChange'] = page => {
-		setCurrent(page)
+		setCurrentPage(page)
 	}
 
 	return (
@@ -183,10 +189,10 @@ const CataloguePage = () => {
 							{catalogueItemsSection}
 						</div>
 						<Pagination
-							current={current}
+							current={currentPage}
 							onChange={onChange}
 							total={filteredCatalogueItems.length}
-							pageSize={5}
+							pageSize={PAGE_SIZE}
 							showSizeChanger={false}
 							showTotal={total => `Total ${total} items`}
 						/>

--- a/src/pages/CataloguePage.tsx
+++ b/src/pages/CataloguePage.tsx
@@ -99,64 +99,71 @@ const CataloguePage = () => {
 					Search Catalogue
 				</span>
 			</div>
-			<div className='flex flex-col py-8 px-10 md:flex-row'>
-				<div className='mr-16 w-full self-start rounded-md bg-gray-50 p-6 md:w-1/3'>
-					<span className='font-semibold text-cloud-burst'>FILTERS</span>
-					<Space style={{ width: '100%' }} direction='vertical'>
-						<div className='pt-3'>
-							<span className='font-bold text-cloud-burst'>Country/Region</span>
-							<Select
-								mode='multiple'
-								allowClear
-								style={{ width: '100%', marginTop: '8px' }}
-								placeholder='Select a country/region...'
-								defaultValue={filters.countryFilter}
-								onChange={onCountryRegionChange}
-								options={countries}
-							/>
-						</div>
-
-						<div className='pt-3'>
-							<span className='font-bold text-cloud-burst'>Year</span>
-							<RangePicker
-								style={{ width: '100%', marginTop: '8px' }}
-								onChange={onYearChange}
-								defaultValue={filters.yearFilter}
-								picker='year'
-								allowEmpty={[true, true]}
-							/>
-						</div>
-
-						<div className='pt-3'>
-							<span className='font-bold text-cloud-burst'>Organization</span>
-							<Select
-								mode='multiple'
-								allowClear
-								style={{ width: '100%', marginTop: '8px' }}
-								placeholder='Select an organization...'
-								defaultValue={filters.organizationFilter}
-								onChange={onOrganizationChange}
-								options={organizations}
-							/>
-						</div>
-
-						<div className='pt-3'>
-							<span className='font-bold text-cloud-burst'>Tags</span>
-							<Select
-								mode='tags'
-								allowClear
-								style={{ width: '100%', marginTop: '8px' }}
-								placeholder='Select a tag...'
-								defaultValue={filters.tagsFilter}
-								onChange={onTagsChange}
-								options={tags}
-							/>
-						</div>
-					</Space>
-				</div>
-				<div className='my-5 flex w-full flex-col md:my-0 md:w-2/3'>
+			<div className='flex flex-col px-10 pb-8 pt-5 '>
+				<div className='pb-5'>
 					<SearchInput onSearchBtnClick={onSearchBtnClick} path='' />
-					<div className='my-3 text-cloud-burst'>{catalogueItemsSection}</div>
+				</div>
+
+				<div className='flex'>
+					<div className='mr-16 w-full self-start rounded-md bg-gray-50 p-6 md:w-1/3'>
+						<span className='font-semibold text-cloud-burst'>FILTERS</span>
+						<Space style={{ width: '100%' }} direction='vertical'>
+							<div className='pt-3'>
+								<span className='font-bold text-cloud-burst'>
+									Country/Region
+								</span>
+								<Select
+									mode='multiple'
+									allowClear
+									style={{ width: '100%', marginTop: '8px' }}
+									placeholder='Select a country/region...'
+									defaultValue={filters.countryFilter}
+									onChange={onCountryRegionChange}
+									options={countries}
+								/>
+							</div>
+
+							<div className='pt-3'>
+								<span className='font-bold text-cloud-burst'>Year</span>
+								<RangePicker
+									style={{ width: '100%', marginTop: '8px' }}
+									onChange={onYearChange}
+									defaultValue={filters.yearFilter}
+									picker='year'
+									allowEmpty={[true, true]}
+								/>
+							</div>
+
+							<div className='pt-3'>
+								<span className='font-bold text-cloud-burst'>Organization</span>
+								<Select
+									mode='multiple'
+									allowClear
+									style={{ width: '100%', marginTop: '8px' }}
+									placeholder='Select an organization...'
+									defaultValue={filters.organizationFilter}
+									onChange={onOrganizationChange}
+									options={organizations}
+								/>
+							</div>
+
+							<div className='pt-3'>
+								<span className='font-bold text-cloud-burst'>Tags</span>
+								<Select
+									mode='tags'
+									allowClear
+									style={{ width: '100%', marginTop: '8px' }}
+									placeholder='Select a tag...'
+									defaultValue={filters.tagsFilter}
+									onChange={onTagsChange}
+									options={tags}
+								/>
+							</div>
+						</Space>
+					</div>
+					<div className='my-5 flex w-full flex-col md:my-0 md:w-2/3'>
+						<div className='my-3 text-cloud-burst'>{catalogueItemsSection}</div>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/src/pages/CataloguePage.tsx
+++ b/src/pages/CataloguePage.tsx
@@ -1,11 +1,15 @@
-import { DatePicker, Select, Skeleton, Space } from 'antd'
+import type { PaginationProps } from 'antd'
+import { DatePicker, Pagination, Select, Skeleton, Space } from 'antd'
 import CatalogueItemCard from 'components/CatalogueItemCard'
+import CustomRadio from 'components/Radio'
 import SearchInput from 'components/SearchInput'
 import { useCatalogueItemContext } from 'context/CatalogueItemContext'
 import { useFilterContext } from 'context/FilterContext'
 import { useSearchContext } from 'context/SearchContext'
+import { useState } from 'react'
 import type { DateFilterType } from 'types/SearchFilters.type'
 import CatalogueHeroImg from '../assets/catalogue-hero-bg.jpg'
+import '../css/Pagination.css'
 
 const { RangePicker } = DatePicker
 
@@ -86,6 +90,12 @@ const CataloguePage = () => {
 		)
 	}
 
+	const [current, setCurrent] = useState<number>(3)
+
+	const onChange: PaginationProps['onChange'] = page => {
+		setCurrent(page)
+	}
+
 	return (
 		<div className='min-h-[calc(100vh_-_3rem)] bg-white'>
 			<div className='relative flex flex-col items-center justify-center py-10 px-10 '>
@@ -162,7 +172,24 @@ const CataloguePage = () => {
 						</Space>
 					</div>
 					<div className='my-5 flex w-full flex-col md:my-0 md:w-2/3'>
-						<div className='my-3 text-cloud-burst'>{catalogueItemsSection}</div>
+						<div className='flex'>
+							<div className='bg-sky-200'>
+								<CustomRadio />
+							</div>
+							<div className='bg-sky-200'>Dropdown</div>
+						</div>
+
+						<div className='my-3  text-cloud-burst'>
+							{catalogueItemsSection}
+						</div>
+						<Pagination
+							current={current}
+							onChange={onChange}
+							total={filteredCatalogueItems.length}
+							pageSize={5}
+							showSizeChanger={false}
+							showTotal={total => `Total ${total} items`}
+						/>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
### Extra details

- Dedicated CSS files were used to override the styles of some of the components
- The filtering mechanisms of both the toggle and dropdown filer are applied after the main filters i.e. the variable that holds the filtered values processed by the old filters are passed down into the new filters then passed into the ui components

### Changelist
- [x] Move search bar to the top
- [x] Add toggle filter for
- [x] Add drop down filter
- [x] Add pagination


### How to test

https://github.com/thinkingmachines/unicef-ai4d-research-bank/assets/122899250/4ae15990-bcd9-4728-94ff-3225bde2eb79


0. For testing pagination, you may need to generate more dummy catalog entries. You can do so by cloning the `yaml` files in the `catalog` folder. Note that spaces and duplicate names are not allowed. Also use this opportunity to change their `year-period` entries, their names and their `card-type` values in order to test the newly added features. Run `pnpm merge-catalog` to generate the new catalog file

1. Assert that the search bar is now located at the top
2. Assert that the pagination works
3. Assert that the toggle filter works
4. Assert that the drop down filter works
5. Assert that the above elements works together