### PR TITLE
feat: various visual enhancements placeholder data download

### DIFF
--- a/src/components/CatalogueItemData.tsx
+++ b/src/components/CatalogueItemData.tsx
@@ -16,6 +16,7 @@ interface Props {
 const CatalogueItemData = ({ catalogueItem }: Props) => {
 	const {
 		links,
+		id,
 		'data-columns': dataColumns,
 		'sample-data': sampleData
 	} = catalogueItem
@@ -32,7 +33,7 @@ const CatalogueItemData = ({ catalogueItem }: Props) => {
 				<span className='mb-1 font-semibold text-gray-700'>
 					Training Datasets
 				</span>
-				{trainingDatasets.map(dataset => (
+				{trainingDatasets.map((dataset, datasetIndex) => (
 					<div className='mb-11 flex flex-row items-center' key={dataset.name}>
 						<div className='flex flex-col'>
 							<div className='mb-2 text-sm font-bold text-gray-700'>
@@ -40,7 +41,7 @@ const CatalogueItemData = ({ catalogueItem }: Props) => {
 							</div>
 							<a
 								href={dataset.url}
-								key={`${dataset.name}`}
+								key={datasetIndex}
 								target='_blank'
 								rel='noreferrer'
 								className='mb-2 hover:underline'
@@ -48,23 +49,27 @@ const CatalogueItemData = ({ catalogueItem }: Props) => {
 								{dataset.description}
 							</a>
 							<div className='flex'>
-								{dataset['alt-format'].map((altFormat, index) => (
-									<div key={index} className='mr-2'>
-										<a
-											href={TEMP_REDIRECT_FORM}
-											key={`${dataset.name}`}
-											target='_blank'
-											rel='noreferrer'
-											className='my-3 rounded-md bg-gray-200  p-10 py-1 pl-2 pr-4 text-left text-xs font-semibold tracking-tight text-gray-600 hover:bg-black hover:bg-opacity-20'
-										>
-											<DownloadOutlined style={{ marginRight: '8px' }} />
-											{getFileFormat(
-												altFormat.type,
-												'training-dataset-'
-											).toUpperCase()}
-										</a>
-									</div>
-								))}
+								{dataset['alt-format']
+									? dataset['alt-format'].map((altFormat, altFormatIndex) => (
+											<div key={altFormatIndex} className='mr-2'>
+												<a
+													href={`${TEMP_REDIRECT_FORM}?item=${id}&url=${encodeURIComponent(
+														altFormat.url
+													)}`}
+													key={altFormatIndex}
+													target='_blank'
+													rel='noreferrer'
+													className='my-3 rounded-md bg-gray-200  p-10 py-1 pl-2 pr-4 text-left text-xs font-semibold tracking-tight text-gray-600 hover:bg-black hover:bg-opacity-20'
+												>
+													<DownloadOutlined style={{ marginRight: '8px' }} />
+													{getFileFormat(
+														altFormat.type,
+														'training-dataset-'
+													).toUpperCase()}
+												</a>
+											</div>
+									  ))
+									: undefined}
 							</div>
 						</div>
 					</div>
@@ -98,28 +103,32 @@ const CatalogueItemData = ({ catalogueItem }: Props) => {
 								</a>
 							</div>
 							<div className='flex'>
-								{dataset['alt-format'].map((altFormat, index) => (
-									<div key={index} className='mr-2 mb-4'>
-										<a
-											href={TEMP_REDIRECT_FORM}
-											key={`${dataset.name}`}
-											target='_blank'
-											rel='noreferrer'
-											className='my-3 rounded-md bg-gray-200  p-10 py-1 pl-2 pr-4 text-left text-xs font-semibold tracking-tight text-gray-600 hover:bg-black hover:bg-opacity-20'
-										>
-											<DownloadOutlined style={{ marginRight: '8px' }} />
-											{altFormat.type.includes('raw')
-												? getFileFormat(
-														altFormat.type,
-														'dataset-raw-'
-												  ).toUpperCase()
-												: getFileFormat(
-														altFormat.type,
-														'dataset-'
-												  ).toUpperCase()}
-										</a>
-									</div>
-								))}
+								{dataset['alt-format']
+									? dataset['alt-format'].map((altFormat, index) => (
+											<div key={index} className='mr-2 mb-4'>
+												<a
+													href={`${TEMP_REDIRECT_FORM}?item=${id}&url=${encodeURIComponent(
+														altFormat.url
+													)}`}
+													key={`${altFormat.type}`}
+													target='_blank'
+													rel='noreferrer'
+													className='my-3 rounded-md bg-gray-200  p-10 py-1 pl-2 pr-4 text-left text-xs font-semibold tracking-tight text-gray-600 hover:bg-black hover:bg-opacity-20'
+												>
+													<DownloadOutlined style={{ marginRight: '8px' }} />
+													{altFormat.type.includes('raw')
+														? getFileFormat(
+																altFormat.type,
+																'dataset-raw-'
+														  ).toUpperCase()
+														: getFileFormat(
+																altFormat.type,
+																'dataset-'
+														  ).toUpperCase()}
+												</a>
+											</div>
+									  ))
+									: undefined}
 							</div>
 						</div>
 					</div>

--- a/src/components/CatalogueItemData.tsx
+++ b/src/components/CatalogueItemData.tsx
@@ -1,8 +1,13 @@
 /* eslint-disable react/jsx-handler-names */
 /* eslint-disable react/no-array-index-key */
+/* eslint-disable react/jsx-props-no-spreading  */
+
+import { DownloadOutlined } from '@ant-design/icons'
+import type { TabsProps } from 'antd'
+import { Tabs } from 'antd'
 import type { CatalogueItemType } from 'types/CatalogueItem.type'
 import { getFileFormat } from 'utils/String.util'
-import CopyLinkButton from './CopyLinkButton'
+import { TEMP_REDIRECT_FORM } from '../constants/index'
 
 interface Props {
 	catalogueItem: CatalogueItemType
@@ -18,7 +23,6 @@ const CatalogueItemData = ({ catalogueItem }: Props) => {
 	const trainingDatasets = links.filter(link =>
 		link.type.includes('training-dataset')
 	)
-
 	const datasets = links.filter(link => link.type.startsWith('dataset-'))
 
 	let trainingDatasetSection
@@ -26,25 +30,43 @@ const CatalogueItemData = ({ catalogueItem }: Props) => {
 		trainingDatasetSection = (
 			<div className='flex flex-col gap-2'>
 				<span className='mb-1 font-semibold text-gray-700'>
-					Training Dataset
+					Training Datasets
 				</span>
 				{trainingDatasets.map(dataset => (
-					<div className='flex flex-row items-center' key={dataset.description}>
-						<div className='w-2/3'>
+					<div className='mb-11 flex flex-row items-center' key={dataset.name}>
+						<div className='flex flex-col'>
+							<div className='mb-2 text-sm font-bold text-gray-700'>
+								{dataset.name}
+							</div>
 							<a
 								href={dataset.url}
-								key={`${dataset.description}`}
+								key={`${dataset.name}`}
 								target='_blank'
 								rel='noreferrer'
-								className='hover:underline'
+								className='mb-2 hover:underline'
 							>
 								{dataset.description}
 							</a>
-							<span className='ml-3 rounded-3xl bg-gray-200 py-1 px-2 text-xs font-semibold text-gray-600'>
-								{getFileFormat(dataset.type, 'training-dataset-').toUpperCase()}
-							</span>
+							<div className='flex'>
+								{dataset['alt-format'].map((altFormat, index) => (
+									<div key={index} className='mr-2'>
+										<a
+											href={TEMP_REDIRECT_FORM}
+											key={`${dataset.name}`}
+											target='_blank'
+											rel='noreferrer'
+											className='my-3 rounded-md bg-gray-200  p-10 py-1 pl-2 pr-4 text-left text-xs font-semibold tracking-tight text-gray-600 hover:bg-black hover:bg-opacity-20'
+										>
+											<DownloadOutlined style={{ marginRight: '8px' }} />
+											{getFileFormat(
+												altFormat.type,
+												'training-dataset-'
+											).toUpperCase()}
+										</a>
+									</div>
+								))}
+							</div>
 						</div>
-						<CopyLinkButton url={dataset.url} />
 					</div>
 				))}
 			</div>
@@ -60,25 +82,46 @@ const CatalogueItemData = ({ catalogueItem }: Props) => {
 				</span>
 				{datasets.map(dataset => (
 					<div className='flex flex-row items-center' key={dataset.description}>
-						<div className='w-2/3'>
-							<a
-								href={dataset.url}
-								key={`${dataset.description}`}
-								target='_blank'
-								rel='noreferrer'
-								className='hover:underline'
-							>
-								{dataset.description}
-							</a>
-							<span className='ml-3 rounded-3xl bg-gray-200 py-1 px-2 text-xs font-semibold text-gray-600'>
-								{dataset.type.includes('raw')
-									? getFileFormat(dataset.type, 'dataset-raw-').toUpperCase()
-									: getFileFormat(dataset.type, 'dataset-').toUpperCase()}
-							</span>
+						<div>
+							<div className='mb-5 text-sm font-bold text-gray-700'>
+								{dataset.name}
+							</div>
+							<div className='mb-3'>
+								<a
+									href={dataset.url}
+									key={`${dataset.description}`}
+									target='_blank'
+									rel='noreferrer'
+									className='hover:underline'
+								>
+									{dataset.description}
+								</a>
+							</div>
+							<div className='flex'>
+								{dataset['alt-format'].map((altFormat, index) => (
+									<div key={index} className='mr-2 mb-4'>
+										<a
+											href={TEMP_REDIRECT_FORM}
+											key={`${dataset.name}`}
+											target='_blank'
+											rel='noreferrer'
+											className='my-3 rounded-md bg-gray-200  p-10 py-1 pl-2 pr-4 text-left text-xs font-semibold tracking-tight text-gray-600 hover:bg-black hover:bg-opacity-20'
+										>
+											<DownloadOutlined style={{ marginRight: '8px' }} />
+											{altFormat.type.includes('raw')
+												? getFileFormat(
+														altFormat.type,
+														'dataset-raw-'
+												  ).toUpperCase()
+												: getFileFormat(
+														altFormat.type,
+														'dataset-'
+												  ).toUpperCase()}
+										</a>
+									</div>
+								))}
+							</div>
 						</div>
-						{dataset.type.includes('raw') && (
-							<CopyLinkButton url={dataset.url} />
-						)}
 					</div>
 				))}
 			</div>
@@ -89,7 +132,6 @@ const CatalogueItemData = ({ catalogueItem }: Props) => {
 	if (dataColumns) {
 		dataColumnsSection = (
 			<div className='flex flex-col'>
-				<span className='mb-1 font-semibold text-gray-700'>Data Schema</span>
 				<div className='flex max-h-[500px] flex-col overflow-y-scroll'>
 					<table className='border-collapse'>
 						<thead>
@@ -118,7 +160,6 @@ const CatalogueItemData = ({ catalogueItem }: Props) => {
 	if (sampleData) {
 		dataPreviewSection = (
 			<div className='flex flex-col'>
-				<span className='mb-1 font-semibold text-gray-700'>Data Preview</span>
 				<table className='block table-auto border-collapse overflow-x-scroll'>
 					{dataColumns ? (
 						<thead>
@@ -159,12 +200,39 @@ const CatalogueItemData = ({ catalogueItem }: Props) => {
 		)
 	}
 
+	const tabItems = [
+		{
+			key: '1',
+			label: '\u00A0 \u00A0 Data Schema',
+			children: dataColumnsSection && dataColumnsSection
+		},
+		{
+			key: '2',
+			label: 'Data Preview',
+			children: dataPreviewSection && dataPreviewSection
+		}
+	]
+
+	const renderTabBar: TabsProps['renderTabBar'] = (props, DefaultTabBar) => (
+		<DefaultTabBar
+			{...props}
+			style={{
+				background: '#F3F4F6',
+				fontWeight: 500,
+				color: '#82838D',
+				marginBottom: 0
+			}}
+		/>
+	)
+
 	return (
-		<div className='mb-5 flex flex-col gap-6'>
+		<div className='mb-5 flex flex-col'>
 			{trainingDatasetSection}
 			{rawDatasetsSection}
-			{dataColumnsSection}
-			{dataPreviewSection}
+			<div className='mt-5 mb-2 font-semibold text-gray-700'>
+				Results Preview
+			</div>
+			<Tabs defaultActiveKey='1' items={tabItems} renderTabBar={renderTabBar} />
 		</div>
 	)
 }

--- a/src/components/CatalogueItemLinks.tsx
+++ b/src/components/CatalogueItemLinks.tsx
@@ -32,7 +32,7 @@ const CatalogueItemLinks = ({ catalogueItem }: Props) => {
 								key={link.description}
 								target='_blank'
 								rel='noreferrer'
-								className='hover:underline'
+								className='text-[#504F54] underline'
 							>
 								{link.description}
 							</a>

--- a/src/components/CatalogueItemOverview.tsx
+++ b/src/components/CatalogueItemOverview.tsx
@@ -1,5 +1,6 @@
 import { InfoCircleOutlined } from '@ant-design/icons'
 import type { CatalogueItemType } from 'types/CatalogueItem.type'
+import MAP_PREVIEW_NOTE from '../constants/texts'
 
 interface Props {
 	catalogueItem: CatalogueItemType
@@ -67,6 +68,10 @@ const CatalogueItemOverview = ({ catalogueItem }: Props) => {
 		return '-'
 	})
 
+	const bannerImage = catalogueItem['detail-image-url']
+		? `../${catalogueItem['detail-image-url']}`
+		: undefined
+
 	return (
 		<div>
 			<p className='mb-5 text-gray-600'>{description}</p>
@@ -78,6 +83,15 @@ const CatalogueItemOverview = ({ catalogueItem }: Props) => {
 					</div>
 				</div>
 			)}
+			{bannerImage ? (
+				<div className='mb-6'>
+					<span className='font-semibold text-gray-700'>Map Preview</span>
+					<p className='mt-3 mb-5 text-gray-600'>{MAP_PREVIEW_NOTE}</p>
+					<div className='text-gray-600'>
+						<img src={bannerImage} alt='BannerImage' />
+					</div>
+				</div>
+			) : undefined}
 		</div>
 	)
 }

--- a/src/components/CopyLinkButton.tsx
+++ b/src/components/CopyLinkButton.tsx
@@ -3,13 +3,14 @@ import { useState } from 'react'
 
 interface Props {
 	url: string
+	placeholder?: string
 }
 
 const onCopyToClipboard = async (text: string) => {
 	await navigator.clipboard.writeText(text)
 }
 
-const CopyLinkButton = ({ url }: Props) => {
+const CopyLinkButton = ({ url, placeholder }: Props) => {
 	const [isCopied, setIsCopied] = useState(false)
 
 	const onCopyClick = () => {
@@ -24,13 +25,17 @@ const CopyLinkButton = ({ url }: Props) => {
 	return (
 		<button
 			type='button'
-			className='ml-auto w-[100px] rounded bg-cloud-burst p-2 text-left tracking-tight text-white hover:bg-opacity-95'
+			className='my-3 rounded-md bg-gray-200  p-10 py-1 pl-2 pr-4 text-left text-xs font-semibold tracking-tight text-gray-600 hover:bg-black hover:bg-opacity-20'
 			onClick={onCopyClick}
 		>
 			<CopyOutlined style={{ marginRight: '8px' }} />
-			{isCopied ? 'Copied!' : 'Copy Link'}
+			{isCopied ? 'Copied!' : placeholder}
 		</button>
 	)
 }
 
 export default CopyLinkButton
+
+CopyLinkButton.defaultProps = {
+	placeholder: 'Enter URL'
+}

--- a/src/components/FeaturedItemCard.tsx
+++ b/src/components/FeaturedItemCard.tsx
@@ -9,55 +9,67 @@ interface Props {
 	image: string
 }
 
-const FeaturedItemCard = ({ item, image }: Props) => (
-	<div className='rounded-md border border-gray-300'>
-		<Link to={`${HOME_PATH}/catalogue/${item.id}`}>
-			<div className='h-[200px]'>
-				<img
-					// src={image}
-					src={`${HOME_PATH}/${item['detail-image-url'] ?? image}`}
-					alt={item.name}
-					className='h-full w-full rounded-t-sm object-cover'
-				/>
-			</div>
-			<div className='flex flex-col py-3 px-5'>
-				<span className='text-xs text-gray-600'>{item.organization.name}</span>
-				<span className='text-base font-semibold text-cloud-burst'>
-					{item.name} ({item['year-period']})
-				</span>
-				<div className='align-center m-t-auto my-2 flex flex-row gap-5'>
-					{item['country-region'] ? (
-						<div className='flex flex-row'>
-							<EnvironmentOutlined
-								style={{
-									color: '#4B5563',
-									marginRight: '4px',
-									fontSize: '14px'
-								}}
-							/>
-							<span className='text-xs text-gray-600'>
-								Country/Region: {formatString(item['country-region'])}
-							</span>
-						</div>
-					) : undefined}
-					{item['year-period'] ? (
-						<div className='flex flex-row'>
-							<CalendarOutlined
-								style={{
-									color: '#4B5563',
-									marginRight: '4px',
-									fontSize: '14px'
-								}}
-							/>
-							<span className='text-xs text-gray-600'>
-								Year/Period: {item['year-period']}
-							</span>
-						</div>
-					) : undefined}
-				</div>
-			</div>
-		</Link>
-	</div>
-)
+const FeaturedItemCard = ({ item, image }: Props) => {
+	const handleItemCardType =
+		item['card-type'] === 'model' ? 'MACHINE LEARNING MODEL' : 'DATASET'
 
+	return (
+		<div className='rounded-md border border-gray-300'>
+			<Link to={`${HOME_PATH}/catalogue/${item.id}`}>
+				<div className='h-[200px]'>
+					<img
+						// src={image}
+						src={`${HOME_PATH}/${item['detail-image-url'] ?? image}`}
+						alt={item.name}
+						className='h-full w-full rounded-t-sm object-cover'
+					/>
+				</div>
+				<div className='flex flex-col py-3 px-5'>
+					<span className='text-xs text-gray-600'>
+						{item.organization.name}
+					</span>
+					<span className='text-base font-semibold text-cloud-burst'>
+						{item.name} ({item['year-period']})
+					</span>
+					<div className='flex'>
+						<div className='align-center my-2 rounded-md bg-[#EDF8FC] py-1  px-2 text-sm font-normal  text-[#24295C] '>
+							{handleItemCardType}
+						</div>
+						<div />
+					</div>
+					<div className='align-center m-t-auto my-2 flex flex-row gap-5'>
+						{item['country-region'] ? (
+							<div className='flex flex-row'>
+								<EnvironmentOutlined
+									style={{
+										color: '#4B5563',
+										marginRight: '4px',
+										fontSize: '14px'
+									}}
+								/>
+								<span className='text-xs text-gray-600'>
+									Country/Region: {formatString(item['country-region'])}
+								</span>
+							</div>
+						) : undefined}
+						{item['year-period'] ? (
+							<div className='flex flex-row'>
+								<CalendarOutlined
+									style={{
+										color: '#4B5563',
+										marginRight: '4px',
+										fontSize: '14px'
+									}}
+								/>
+								<span className='text-xs text-gray-600'>
+									Year/Period: {item['year-period']}
+								</span>
+							</div>
+						) : undefined}
+					</div>
+				</div>
+			</Link>
+		</div>
+	)
+}
 export default FeaturedItemCard

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -22,3 +22,10 @@ export const SELECT_OPTIONS = {
 } as const
 
 export type SelectOption = (typeof SELECT_OPTIONS)[keyof typeof SELECT_OPTIONS]
+
+export const TEMP_NUMBER_OF_DOWNLOADS = 121
+
+export const TEMP_WHO_DOWNLOADED = ['UNICEF', 'WFP', 'WHO']
+
+export const TEMP_REDIRECT_FORM =
+	'https://inform.unicef.org/eapro/researchbank/downloadform?url='

--- a/src/constants/texts.ts
+++ b/src/constants/texts.ts
@@ -1,0 +1,4 @@
+const MAP_PREVIEW_NOTE =
+	'Note: The following visualization represents the geographical scope of the dataset. [Disclaimer on the map visualization, this language can be improved.]'
+
+export default MAP_PREVIEW_NOTE

--- a/src/constants/texts.ts
+++ b/src/constants/texts.ts
@@ -1,4 +1,4 @@
 const MAP_PREVIEW_NOTE =
-	'Note: The following visualization represents the geographical scope of the dataset. [Disclaimer on the map visualization, this language can be improved.]'
+	'Note: The following visualization represents the geographical scope of the dataset.'
 
 export default MAP_PREVIEW_NOTE

--- a/src/pages/CatalogueItemPage.tsx
+++ b/src/pages/CatalogueItemPage.tsx
@@ -226,7 +226,7 @@ const CatalogueItemPage = () => {
 					</div>
 					<div className='rounded bg-gray-50 p-5'>
 						<span className='text-sm font-semibold'>
-							This dataset has been used by:
+							This dataset has been downloaded by:
 						</span>
 						{TEMP_WHO_DOWNLOADED.map(data => (
 							<div className='flex flex-wrap gap-3 py-3' key={data}>

--- a/src/pages/CatalogueItemPage.tsx
+++ b/src/pages/CatalogueItemPage.tsx
@@ -2,8 +2,7 @@
 import {
 	CalendarOutlined,
 	EnvironmentOutlined,
-	TagsOutlined,
-	TeamOutlined
+	TagsOutlined
 } from '@ant-design/icons'
 import { Skeleton, Tabs } from 'antd'
 import CatalogueItemData from 'components/CatalogueItemData'
@@ -193,28 +192,7 @@ const CatalogueItemPage = () => {
 									</span>
 								</div>
 							</div>
-							<div className='align-center flex flex-row gap-3'>
-								<TeamOutlined
-									style={{
-										color: '#6b7280',
-										fontSize: '24px',
-										margin: 'auto 0'
-									}}
-								/>
-								<div className='flex flex-col'>
-									<span className='text-xs font-medium text-gray-500'>
-										ORGANIZATION
-									</span>
-									<a
-										href={organization.url}
-										target='_blank'
-										rel='noreferrer'
-										className='text-sm font-medium hover:underline'
-									>
-										{organization.name}
-									</a>
-								</div>
-							</div>
+
 							<div className='align-center flex flex-row gap-3'>
 								<CalendarOutlined
 									style={{
@@ -243,6 +221,14 @@ const CatalogueItemPage = () => {
 								</div>
 							) : undefined}
 						</div>
+					</div>
+					<div className='rounded bg-gray-50 p-5'>
+						<span className='text-sm font-semibold'>
+							This dataset has been used by:
+						</span>
+						<div className='flex flex-wrap gap-3 py-3'>Unicef1</div>
+						<div className='flex flex-wrap gap-3 py-3'>Unicef2</div>
+						<div className='flex flex-wrap gap-3 py-3'>Unicef3</div>
 					</div>
 					<div className='rounded bg-gray-50 p-5'>
 						<span className='text-sm font-semibold'>

--- a/src/pages/CatalogueItemPage.tsx
+++ b/src/pages/CatalogueItemPage.tsx
@@ -17,6 +17,10 @@ import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { formatString } from 'utils/String.util'
 import Tag from '../components/Tag'
+import {
+	TEMP_NUMBER_OF_DOWNLOADS,
+	TEMP_WHO_DOWNLOADED
+} from '../constants/index'
 import type { CatalogueItemType } from '../types/CatalogueItem.type'
 
 const defaultFilters = {
@@ -120,8 +124,6 @@ const CatalogueItemPage = () => {
 
 	const bannerImage = detailImage ? `../${detailImage}` : null
 
-	const NUMBER_OF_DOWNLOADS = 121
-
 	return (
 		<div className='min-h-[calc(100vh_-_3rem)] bg-white'>
 			<div className='relative flex min-h-[10rem] flex-col items-center justify-center bg-cloud-burst p-10'>
@@ -147,7 +149,7 @@ const CatalogueItemPage = () => {
 						{organization.name}
 					</a>
 					<div>&#8226;</div>
-					<div>{NUMBER_OF_DOWNLOADS} downloads</div>
+					<div>{TEMP_NUMBER_OF_DOWNLOADS} downloads</div>
 				</div>
 			</div>
 
@@ -226,9 +228,11 @@ const CatalogueItemPage = () => {
 						<span className='text-sm font-semibold'>
 							This dataset has been used by:
 						</span>
-						<div className='flex flex-wrap gap-3 py-3'>Unicef1</div>
-						<div className='flex flex-wrap gap-3 py-3'>Unicef2</div>
-						<div className='flex flex-wrap gap-3 py-3'>Unicef3</div>
+						{TEMP_WHO_DOWNLOADED.map(data => (
+							<div className='flex flex-wrap gap-3 py-3' key={data}>
+								{data}
+							</div>
+						))}
 					</div>
 					<div className='rounded bg-gray-50 p-5'>
 						<span className='text-sm font-semibold'>

--- a/src/pages/CatalogueItemPage.tsx
+++ b/src/pages/CatalogueItemPage.tsx
@@ -92,7 +92,8 @@ const CatalogueItemPage = () => {
 		'date-modified': dateModified,
 		'year-period': yearPeriod,
 		'country-region': countryRegion,
-		tags
+		tags,
+		'detail-image-url': detailImage
 	} = catalogueItem
 
 	let yearPeriodTitle
@@ -118,34 +119,40 @@ const CatalogueItemPage = () => {
 		}
 	]
 
+	const bannerImage = detailImage ? `../${detailImage}` : null
+
+	const NUMBER_OF_DOWNLOADS = 121
+
 	return (
 		<div className='min-h-[calc(100vh_-_3rem)] bg-white'>
-			<div className='flex min-h-[10rem] flex-col bg-cloud-burst p-10 text-white'>
-				<a
-					href={organization.url}
-					className='text-sm hover:underline'
-					target='_blank'
-					rel='noreferrer'
-				>
-					{organization.name}
-				</a>
-				<span className='text-3xl font-medium tracking-tighter'>
+			<div className='relative flex min-h-[10rem] flex-col items-center justify-center bg-cloud-burst p-10'>
+				{detailImage ? (
+					<img
+						src={bannerImage ?? ''}
+						alt='BannerImage'
+						className='bg absolute z-0 h-full w-full object-cover'
+					/>
+				) : null}
+				<div className='absolute z-10 h-full w-full bg-cloud-burst opacity-80 brightness-75' />
+
+				<span className='z-20 self-start pl-28 text-3xl font-medium tracking-tighter'>
 					{name} {yearPeriodTitle}
 				</span>
-				<div className='mt-2 flex flex-row gap-10 text-sm'>
-					<span>
-						<EnvironmentOutlined />{' '}
-						{countryRegion
-							? `Country/Region: ${formatString(countryRegion)}`
-							: '-'}
-					</span>
-					<span>
-						<CalendarOutlined />{' '}
-						{yearPeriod ? `Year/Period: ${yearPeriod}` : '-'}
-					</span>
+				<div className='z-20 mt-2 flex flex-row gap-3 self-start pl-28 text-sm'>
+					<a
+						href={organization.url}
+						className='z-20 self-start text-sm hover:underline'
+						target='_blank'
+						rel='noreferrer'
+					>
+						{organization.name}
+					</a>
+					<div>&#8226;</div>
+					<div>{NUMBER_OF_DOWNLOADS} downloads</div>
 				</div>
 			</div>
-			<div className='flex flex-col md:flex-row'>
+
+			<div className='flex flex-col pl-28 md:flex-row'>
 				<div className='flex w-full flex-col gap-4 p-10 text-cloud-burst md:w-2/3'>
 					<Tabs defaultActiveKey='1' items={tabItems} />
 				</div>

--- a/src/types/CatalogueItem.type.ts
+++ b/src/types/CatalogueItem.type.ts
@@ -43,11 +43,11 @@ export interface MetricLink {
 }
 
 export interface LinkType {
-	url: string
+	url?: string
 	description: string
 	type: string
-	name: string
-	'alt-format': AltFormatType[]
+	name?: string
+	'alt-format'?: AltFormatType[]
 }
 
 export interface AltFormatType {

--- a/src/types/CatalogueItem.type.ts
+++ b/src/types/CatalogueItem.type.ts
@@ -43,7 +43,14 @@ export interface MetricLink {
 }
 
 export interface LinkType {
+	url: string
 	description: string
+	type: string
+	name: string
+	'alt-format': AltFormatType[]
+}
+
+export interface AltFormatType {
 	url: string
 	type: string
 }


### PR DESCRIPTION
###  Extra details

- all dummy data is in the `constants` folder

### Changelist
- [x] Add `card-type` tag to featured dataset in landing page
- [x] Add a map preview to catalog items
- [x] Add `dataset has been used by` and `downloads` base with dummy data
- [x] Add various visual enhancements to `catalog-item data tab` 
- [x] Make download `csv` or `geoJSON` files temporarily link to unicef form link
- [x] Add underline from related links in  `catalog item RELATED tab`

### How to test

1. Assert that the all the visual enhancements mentioned above are present
2. Assert that the downloading of CSVs or GEOJSONS redirect to the dummy link

[Wireframe](https://www.figma.com/file/uKFcwlIWJuadonbCejcZcy/Unicef-Open-Source-Web-App?type=design&node-id=823-2&t=49JYGjpKXdbm9SX7-0)


https://github.com/thinkingmachines/unicef-ai4d-research-bank/assets/122899250/110e1708-2cb9-463b-95dc-e10c675b1684


