### PR TITLE
tests: add landing page tests

### DIFF
--- a/cypress/e2e/index.spec.ts
+++ b/cypress/e2e/index.spec.ts
@@ -2,22 +2,29 @@ describe('Access all resources', () => {
 	it('renders the main page ', () => {
 		cy.visit('/')
 	})
+
 	it('fetch the catalog json file ', () => {
 		cy.request('/api/data/catalog.json')
 	})
+
 	it('should navigate to the catalog page on click', () => {
 		cy.contains('Catalogue').click()
 		cy.location('pathname').should('eq', `/unicef-ai4d-research-bank/catalogue`)
 	})
+
 	it('should navigate to the catalog item page on click', () => {
 		// eslint-disable-next-line cypress/no-unnecessary-waiting
 		cy.wait(3000)
-		cy.contains('Poverty Mapping Model for Timor Leste').click()
+		cy.contains(
+			'Poverty Mapping Rollout Dataset for Timor Leste (2016)'
+		).click()
+
 		cy.location('pathname').should(
 			'eq',
-			`/unicef-ai4d-research-bank/catalogue/povmap-timor-leste`
+			`/unicef-ai4d-research-bank/catalogue/povmap-timor-leste-rollout-dataset`
 		)
 	})
+
 	it('should navigate to the main page', () => {
 		cy.contains('AI4D Research Bank').click()
 		cy.location('pathname').should('eq', `/unicef-ai4d-research-bank/`)

--- a/cypress/e2e/landing-page.spec.ts
+++ b/cypress/e2e/landing-page.spec.ts
@@ -1,0 +1,128 @@
+/* eslint-disable cypress/no-unnecessary-waiting */
+/* eslint-disable cypress/require-data-selectors */
+
+describe('The correct elements are visible in the landing page', () => {
+	it('renders the main page ', () => {
+		cy.visit('/')
+	})
+
+	it('fetch the catalog json file ', () => {
+		cy.request('/api/data/catalog.json')
+	})
+
+	it('renders the hero', () => {
+		cy.get('[data-cy="hero-mainText"]').contains(
+			'Accelerating machine learning adoption in the development sector'
+		)
+		cy.get('[data-cy="hero-subtext"]').contains(
+			'Browse our catalogue of models and datasets to gain access to code, documentation, and pre-processed datasets that fit to your needs'
+		)
+		cy.get('[data-cy="hero-search"]').should('be.visible')
+	})
+
+	it('renders the featured datasets', () => {
+		cy.get('[data-cy="featured-datasets"]').should('be.visible')
+	})
+
+	it('renders the browse by tags', () => {
+		cy.get('[data-cy="tag-browse"]').should('be.visible')
+	})
+
+	it('renders the browse by country/region', () => {
+		cy.get('[data-cy="region-browse"]').should('be.visible')
+	})
+})
+
+describe('Clicking the "browse by tags" auto populate the catalogue filters', () => {
+	it('renders at least three tags', () => {
+		cy.wait(3000)
+
+		cy.get('[data-cy="tag-browse"]').within(() => {
+			cy.contains('button', 'air-quality').should('be.visible')
+
+			cy.contains('button', 'machine-learning').should('be.visible')
+
+			cy.contains('button', 'philippines').should('be.visible')
+		})
+	})
+
+	it('redirects to the search catalogue page', () => {
+		cy.request('/api/data/catalog.json')
+		cy.contains('button', 'air-quality').click()
+		cy.location('pathname').should('eq', `/unicef-ai4d-research-bank/catalogue`)
+	})
+
+	it('renders the search catalogue page', () => {
+		cy.contains('Search Catalogue')
+	})
+
+	it('auto populates the Tags filter', () => {
+		cy.contains('air-quality')
+	})
+})
+
+describe('Clicking the "browse by tags" clears previously added filters', () => {
+	it('should add three selections to tag filter', () => {
+		cy.visit('/catalogue')
+
+		cy.get('[data-cy="select-tags"]').click()
+		cy.contains('.ant-select-item-option-content', 'air-quality').click()
+		cy.contains('.ant-select-item-option-content', 'machine-learning').click()
+		cy.contains('.ant-select-item-option-content', 'philippines').click()
+	})
+
+	it('should have only one selection in tag filter ', () => {
+		cy.visit('/')
+		cy.get('[data-cy="tag-browse"]').contains('machine-learning').click()
+
+		cy.get('span.ant-select-selection-item-content').should(
+			'not.contain',
+			'air-quality'
+		)
+		cy.get('span.ant-select-selection-item-content').should(
+			'not.contain',
+			'philippines'
+		)
+	})
+})
+
+describe('Landing page autocomplete on search should lead to catalog page', () => {
+	it('should redirect to catalogue with the inputted search term', () => {
+		cy.visit('/')
+
+		cy.get('input[placeholder="Search for a dataset or a model"]')
+			.click()
+			.type('cross country poverty')
+
+		cy.get('span.ant-input-group-addon').find('button').click()
+		cy.location('pathname').should('eq', `/unicef-ai4d-research-bank/catalogue`)
+
+		cy.contains(
+			'Cross Country Poverty Mapping Model for Indonesia, Timor Leste and Myanmar (2016)'
+		)
+	})
+})
+
+describe('Searching from the landing page should reset the tag filters', () => {
+	it('should add three selections to tag filter', () => {
+		cy.visit('/catalogue')
+
+		cy.get('[data-cy="select-tags"]').click()
+		cy.contains('.ant-select-item-option-content', 'air-quality').click()
+		cy.contains('.ant-select-item-option-content', 'machine-learning').click()
+		cy.contains('.ant-select-item-option-content', 'philippines').click()
+	})
+
+	it('should have only no selections in tag filter ', () => {
+		cy.visit('/')
+
+		cy.get('input[placeholder="Search for a dataset or a model"]')
+			.click()
+			.type('cross country poverty')
+
+		cy.get('span.ant-input-group-addon').find('button').click()
+		cy.location('pathname').should('eq', `/unicef-ai4d-research-bank/catalogue`)
+
+		cy.get('span.ant-select-selection-item-content').should('not.exist')
+	})
+})

--- a/src/pages/CataloguePage.tsx
+++ b/src/pages/CataloguePage.tsx
@@ -233,6 +233,7 @@ const CataloguePage = () => {
 									defaultValue={filters.tagsFilter}
 									onChange={onTagsChange}
 									options={tags}
+									data-cy='select-tags'
 								/>
 							</div>
 						</Space>

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -73,14 +73,17 @@ const LandingPage = () => {
 				/>
 				<div className='absolute z-10 h-full w-full bg-cloud-burst opacity-60' />
 				<div className='z-20 flex flex-col items-center justify-center'>
-					<span className='mb-3 text-center text-2xl font-medium tracking-tighter text-white md:text-4xl'>
+					<span
+						className='mb-3 text-center text-2xl font-medium tracking-tighter text-white md:text-4xl'
+						data-cy='hero-mainText'
+					>
 						Accelerating machine learning adoption in the development sector
 					</span>
-					<span className='px-10 text-center'>
+					<span className='px-10 text-center' data-cy='hero-subtext'>
 						Browse our catalogue of models and datasets to gain access to code,
 						documentation, and pre-processed datasets that fit to your needs
 					</span>
-					<div className='my-5 flex w-2/3 flex-row'>
+					<div className='my-5 flex w-2/3 flex-row' data-cy='hero-search'>
 						<SearchInput
 							onSearchBtnClick={onSearchBtnClick}
 							path='catalogue/'
@@ -88,7 +91,7 @@ const LandingPage = () => {
 					</div>
 				</div>
 			</div>
-			<div className='flex flex-col p-10'>
+			<div className='flex flex-col p-10' data-cy='featured-datasets'>
 				<span className='font-semibold tracking-normal text-cloud-burst'>
 					FEATURED DATASETS
 				</span>
@@ -107,7 +110,10 @@ const LandingPage = () => {
 				</div>
 			</div>
 			<div className='flex flex-col md:flex-row'>
-				<div className='flex w-full flex-col p-10 md:w-1/2'>
+				<div
+					className='flex w-full flex-col p-10 md:w-1/2'
+					data-cy='tag-browse'
+				>
 					<span className='font-semibold tracking-normal text-cloud-burst'>
 						BROWSE BY TAGS
 					</span>
@@ -128,7 +134,10 @@ const LandingPage = () => {
 					</div>
 				</div>
 				<div className='flex w-full flex-col p-10 md:w-1/2'>
-					<span className='font-semibold tracking-normal text-cloud-burst'>
+					<span
+						className='font-semibold tracking-normal text-cloud-burst'
+						data-cy='region-browse'
+					>
 						BROWSE BY COUNTRY/REGION
 					</span>
 					<div className='flex flex-wrap gap-3 py-3 text-cloud-burst'>


### PR DESCRIPTION
### extra details

- The eslint disable snippet `/* eslint-disable cypress/require-data-selectors */` is used since antd components make heavy use of class selections which are frowned upon by this linting rule

### changelog

- [x] added tests detailed in the landing page section [here](https://github.com/thinkingmachines/unicef-ai4d-research-bank/wiki/Frontend-Test-Cases)

### how to test

0. Make sure you have cypress installed
1. Run `pnpm merge-catalog`
2. Run `pnpm build`
3. Run `pnpm test:e2e:headless` to run all tests or `pnpm test:e2e` to run the tests via a GUI
4. Assert that all the tests pass