### PR TITLE
feat: sprint 6 E2E tests 

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'cypress'
 
 export default defineConfig({
 	fileServerFolder: 'dist',
-	fixturesFolder: false,
+	fixturesFolder: 'public/api/data',
 	projectId: 'ivvovd',
 	e2e: {
 		chromeWebSecurity: false,

--- a/cypress/.eslintrc.js
+++ b/cypress/.eslintrc.js
@@ -35,7 +35,9 @@ module.exports = {
 				'cypress/no-force': 'error',
 				'cypress/assertion-before-screenshot': 'error',
 				'cypress/require-data-selectors': 'error',
-				'cypress/no-pause': 'error'
+				'cypress/no-pause': 'error',
+				'cypress/no-unnecessary-waiting': 'off',
+				'cypress/require-data-selectors': 'off'
 			}
 		}
 	]

--- a/cypress/e2e/catalog-item.spec.ts
+++ b/cypress/e2e/catalog-item.spec.ts
@@ -1,0 +1,86 @@
+describe('The catalog item sub components display correctly', () => {
+	before(() => {
+		cy.visit('/')
+		cy.request('/api/data/catalog.json')
+		cy.wait(3000)
+	})
+
+	it('should visit the catalog search page', () => {
+		cy.contains('Catalogue').click()
+		cy.location('pathname').should('eq', `/unicef-ai4d-research-bank/catalogue`)
+	})
+
+	it('should visit the specific catalog item page', () => {
+		cy.contains('Poverty Mapping Model for Philippines (2017)').click()
+		cy.location('pathname').should(
+			'eq',
+			`/unicef-ai4d-research-bank/catalogue/povmap-philippines`
+		)
+	})
+
+	it('should display the organization name', () => {
+		cy.contains('Thinking Machines Data Sciences Inc')
+	})
+
+	it('should display the dataset/model name', () => {
+		cy.contains('Poverty Mapping Model for Philippines (2017)')
+	})
+
+	it('should display the Overview, Data, and Related links tab', () => {
+		cy.get('[role="tab"]').contains('Overview').should('exist')
+		cy.get('[role="tab"]').contains('Data').should('exist')
+		cy.get('[role="tab"]').contains('Related Links').should('exist')
+	})
+
+	it('should display the country/region, year/period, and date created in the rightmost side', () => {
+		cy.get('[data-cy="catalog-item-aside"]').contains('COUNTRY / REGION')
+		cy.get('[data-cy="catalog-item-aside"]').contains('YEAR / PERIOD')
+		cy.get('[data-cy="catalog-item-aside"]').contains('DATE CREATED')
+	})
+
+	it('should display the tags', () => {
+		cy.get('[data-cy="catalog-item-aside-tags"]').contains('poverty-mapping')
+		cy.get('[data-cy="catalog-item-aside-tags"]').contains('philippines')
+	})
+
+	it('should display the description in under the overview tab', () => {
+		cy.contains(
+			'This is an sklearn Random Forest regressor model for predicting relative wealth for Philippines.'
+		)
+	})
+
+	it('should display the evalution metric', () => {
+		cy.contains('Evaluation Metric')
+		cy.contains('RSQUARED')
+		cy.contains('Model evaluation using cross-validation')
+	})
+})
+
+describe('The data columns should render correctly', () => {
+	before(() => {
+		cy.visit('/')
+		cy.request('/api/data/catalog.json')
+		cy.wait(3000)
+	})
+
+	it('should visit the catalog search page', () => {
+		cy.contains('Catalogue').click()
+		cy.location('pathname').should('eq', `/unicef-ai4d-research-bank/catalogue`)
+	})
+
+	it('should visit the specific catalog item page', () => {
+		cy.contains(
+			'Poverty Mapping Rollout Dataset for Timor Leste (2016)'
+		).click()
+		cy.location('pathname').should(
+			'eq',
+			`/unicef-ai4d-research-bank/catalogue/povmap-timor-leste-rollout-dataset`
+		)
+	})
+
+	it('it should display two columns: column name and column type', () => {
+		cy.get('[role="tab"]').contains('Data').should('exist').click()
+		cy.get('[data-cy="catalog-item-data-schema"]').contains('Column Name')
+		cy.get('[data-cy="catalog-item-data-schema"]').contains('Type')
+	})
+})

--- a/cypress/e2e/catalog-page.spec.ts
+++ b/cypress/e2e/catalog-page.spec.ts
@@ -1,0 +1,111 @@
+import type { CatalogueItemType } from '../../src/types/CatalogueItem.type'
+
+describe('The catalog page renders', () => {
+	before(() => {
+		cy.visit('/catalogue')
+		cy.request('/api/data/catalog.json')
+		cy.wait(3000)
+	})
+
+	it('renders the filter ', () => {
+		cy.get('span')
+			.contains('Country/Region')
+			.siblings('div.ant-select')
+			.should('exist')
+
+		cy.get('span').contains('Year').siblings('div.ant-picker').should('exist')
+
+		cy.get('span')
+			.contains('Organization')
+			.siblings('div.ant-select')
+			.should('exist')
+
+		cy.get('span').contains('Tags').siblings('div.ant-select').should('exist')
+	})
+
+	it('renders the search box ', () => {
+		cy.get('input[placeholder="Search for a dataset or a model"]').should(
+			'exist'
+		)
+	})
+
+	it('renders the number of results', () => {
+		cy.get('span').contains('results available')
+	})
+
+	it('renders the actual results ', () => {
+		cy.get('span')
+			.contains('results available')
+			.siblings('div')
+			.find('a')
+			.should('have.length', 5)
+	})
+})
+
+describe('all models and datasets should be displayed by default', () => {
+	let catalogDataLength: number
+
+	before(() => {
+		cy.fixture('catalog.json').then((data: CatalogueItemType[]) => {
+			catalogDataLength = data.length
+		})
+	})
+
+	it('should render all the default items', () => {
+		cy.visit('/')
+
+		cy.contains('Catalogue').click()
+		cy.location('pathname').should('eq', `/unicef-ai4d-research-bank/catalogue`)
+
+		if (catalogDataLength > 5) {
+			cy.get('span')
+				.contains('results available')
+				.siblings('div')
+				.find('a')
+				.should('have.length', 5)
+		} else {
+			cy.get('span')
+				.contains('results available')
+				.siblings('div')
+				.find('a')
+				.should('have.length', catalogDataLength)
+		}
+	})
+})
+
+describe('clicking on a search result should redirect the user to the selected catalogue item page', () => {
+	let catalogData: CatalogueItemType[]
+
+	before(() => {
+		cy.fixture('catalog.json').then((data: CatalogueItemType[]) => {
+			catalogData = data
+		})
+	})
+
+	it('renders the main page ', () => {
+		cy.visit('/')
+	})
+
+	it('fetch the catalog json file ', () => {
+		cy.request('/api/data/catalog.json')
+	})
+
+	it('should navigate to the catalog page on click', () => {
+		cy.contains('Catalogue').click()
+		cy.location('pathname').should('eq', `/unicef-ai4d-research-bank/catalogue`)
+
+		cy.get('span')
+			.contains('results available')
+			.siblings('div')
+			.find('a')
+			.first()
+			.click()
+
+		cy.log(catalogData[0].id)
+
+		cy.location('pathname').should(
+			'eq',
+			`/unicef-ai4d-research-bank/catalogue/${catalogData[0].id}`
+		)
+	})
+})

--- a/cypress/e2e/featured-dataset.spec.ts
+++ b/cypress/e2e/featured-dataset.spec.ts
@@ -1,0 +1,74 @@
+describe('There should only be a maximum of 3 featured datasets', () => {
+	before(() => {
+		cy.visit('/catalogue')
+		cy.request('/api/data/catalog.json')
+		cy.wait(3000)
+	})
+
+	it('should display 3 dataset cards', () => {
+		cy.visit('/')
+		cy.request('/api/data/catalog.json')
+
+		cy.get('[data-cy="featured-card"]').its('length').should('eq', 3)
+	})
+})
+
+describe('The featured cards should display the correct sub components', () => {
+	before(() => {
+		cy.visit('/catalogue')
+		cy.request('/api/data/catalog.json')
+		cy.wait(3000)
+	})
+
+	it('should display the org name', () => {
+		cy.visit('/')
+		cy.request('/api/data/catalog.json')
+
+		cy.get('[data-cy="featured-card-org-name"]').its('length').should('eq', 3)
+	})
+
+	it('should display the card name', () => {
+		cy.visit('/')
+		cy.request('/api/data/catalog.json')
+
+		cy.get('[data-cy="featured-card-name"]').its('length').should('eq', 3)
+	})
+
+	it('should display the country-region name', () => {
+		cy.visit('/')
+		cy.request('/api/data/catalog.json')
+
+		cy.get('[data-cy="featured-card-country-region"]')
+			.its('length')
+			.should('eq', 3)
+	})
+
+	it('should display the year/period', () => {
+		cy.visit('/')
+		cy.request('/api/data/catalog.json')
+
+		cy.get('[data-cy="featured-card-year-period"]')
+			.its('length')
+			.should('eq', 3)
+	})
+})
+
+describe('Clicking on a featured dataset should redirect to the catalogue item page', () => {
+	before(() => {
+		cy.visit('/catalogue')
+		cy.request('/api/data/catalog.json')
+		cy.wait(3000)
+	})
+
+	it('should redirect to the catalogue id page with the same id as the featured dataset', () => {
+		cy.visit('/')
+		cy.request('/api/data/catalog.json')
+
+		cy.contains('Air Quality Model for Thailand').click()
+
+		cy.location('pathname').should(
+			'eq',
+			`/unicef-ai4d-research-bank/catalogue/airquality-thailand-model`
+		)
+	})
+})

--- a/cypress/e2e/filter.spec.ts
+++ b/cypress/e2e/filter.spec.ts
@@ -1,0 +1,149 @@
+describe('The correct filter elements should be displayed', () => {
+	before(() => {
+		cy.visit('/catalogue')
+		cy.request('/api/data/catalog.json')
+		// cy.wait(3000)
+	})
+
+	it('renders the filter ', () => {
+		cy.get('span')
+			.contains('Country/Region')
+			.siblings('div.ant-select')
+			.should('exist')
+
+		cy.get('span').contains('Year').siblings('div.ant-picker').should('exist')
+
+		cy.get('span')
+			.contains('Organization')
+			.siblings('div.ant-select')
+			.should('exist')
+
+		cy.get('span').contains('Tags').siblings('div.ant-select').should('exist')
+	})
+})
+
+describe('The country/regions filter options in alphabetical order', () => {
+	it('should assert that the country/region filter  choices are alphabetical ', () => {
+		cy.get('span').contains('Country/Region').siblings('div.ant-select').click()
+
+		cy.get('div.rc-virtual-list-holder-inner')
+			.children('div')
+			.eq(0)
+			.should('contain', 'Indonesia')
+			.next()
+			.should('contain', 'Myanmar')
+			.next()
+			.should('contain', 'Philippines')
+			.next()
+			.should('contain', 'Thailand')
+			.next()
+			.should('contain', 'Timor Leste')
+	})
+})
+
+describe('The country/regions filter should clear upon pressing x', () => {
+	it('should select two options from the filter', () => {
+		cy.get('span')
+			.contains('Country/Region')
+			.siblings('div.ant-select')
+			.click()
+			.type('{downArrow}{downArrow}{enter}{downArrow}{enter}')
+
+		cy.contains('.ant-select-selector', 'Thailand')
+		cy.contains('.ant-select-selector', 'Philippines')
+	})
+
+	it('should clear out the selected filters', () => {
+		cy.get('.ant-select').eq(1).click()
+
+		cy.contains('.ant-select-selector', 'Thailand')
+		cy.contains('.ant-select-selector', 'Philippines')
+
+		cy.get('.ant-select-clear').click()
+
+		cy.contains('.ant-select-selector', 'Thailand').should('not.exist')
+		cy.contains('.ant-select-selector', 'Philippines').should('not.exist')
+	})
+})
+
+describe('The number of results should be 0 if using tag filter with a tag does not exist', () => {
+	it('should display no catalogue items', () => {
+		cy.get('span')
+			.contains('Tags')
+			.siblings('div.ant-select')
+			.click()
+			.type('test{enter}')
+
+		cy.contains('No catalogue items available.')
+	})
+})
+
+describe('The search entries should only entries from year 2017 till present', () => {
+	it('Sets start year to 2017 and verifies results', () => {
+		cy.visit('/catalogue')
+
+		cy.get('.ant-picker-input').eq(0).click()
+
+		cy.get('.ant-picker-header-super-prev-btn').eq(0).click()
+
+		cy.contains('.ant-picker-cell-inner', '2017').first().click()
+
+		cy.contains('3 results available').should('be.visible')
+	})
+})
+
+describe('The search entries should only entries from before year 2019', () => {
+	it('Sets end year to 2019 and verifies results', () => {
+		cy.visit('/catalogue')
+
+		cy.get('.ant-picker-input').eq(1).click()
+
+		cy.get('.ant-picker-header-super-prev-btn').eq(0).click()
+
+		cy.contains('.ant-picker-cell-inner', '2019').first().click()
+
+		cy.contains('4 results available').should('be.visible')
+	})
+})
+
+describe('Filter year/period for entries spanning multiple entries', () => {
+	it('Sets end year to 2019 and verifies results', () => {
+		cy.visit('/catalogue')
+
+		cy.get('.ant-picker-input').eq(0).click()
+
+		cy.get('.ant-picker-header-super-prev-btn').eq(0).click()
+
+		cy.contains('.ant-picker-cell-inner', '2017').first().click()
+
+		cy.get('.ant-picker-header-super-next-btn').eq(1).click()
+		cy.contains('.ant-picker-cell-inner', '2021').first().click()
+
+		cy.contains('Air Quality Model for Thailand (2020-2023)').should(
+			'be.visible'
+		)
+	})
+})
+
+describe('Filter for a single year', () => {
+	it('Sets end year to 2019 and verifies results', () => {
+		cy.visit('/catalogue')
+
+		cy.get('.ant-picker-input').eq(0).click()
+
+		cy.get('.ant-picker-header-super-prev-btn').eq(0).click()
+
+		cy.contains('.ant-picker-cell-inner', '2016').first().click()
+		cy.contains('.ant-picker-cell-inner', '2016').first().click()
+
+		cy.contains(
+			'Cross Country Poverty Mapping Model for Indonesia, Timor Leste and Myanmar'
+		).should('be.visible')
+
+		cy.contains('Poverty Mapping Rollout Dataset for Timor Leste').should(
+			'be.visible'
+		)
+
+		cy.contains('Poverty Mapping Model for Timor Leste').should('be.visible')
+	})
+})

--- a/cypress/e2e/filter.spec.ts
+++ b/cypress/e2e/filter.spec.ts
@@ -72,7 +72,7 @@ describe('The number of results should be 0 if using tag filter with a tag does 
 			.contains('Tags')
 			.siblings('div.ant-select')
 			.click()
-			.type('test{enter}')
+			.type('NoneExistentTag{enter}')
 
 		cy.contains('No catalogue items available.')
 	})
@@ -102,7 +102,7 @@ describe('The search entries should only entries from before year 2019', () => {
 
 		cy.contains('.ant-picker-cell-inner', '2019').first().click()
 
-		cy.contains('4 results available').should('be.visible')
+		cy.contains('5 results available').should('be.visible')
 	})
 })
 

--- a/cypress/e2e/filter.spec.ts
+++ b/cypress/e2e/filter.spec.ts
@@ -107,7 +107,7 @@ describe('The search entries should only entries from before year 2019', () => {
 })
 
 describe('Filter year/period for entries spanning multiple entries', () => {
-	it('Sets end year to 2019 and verifies results', () => {
+	it('Sets end year to 2021 and verifies results', () => {
 		cy.visit('/catalogue')
 
 		cy.get('.ant-picker-input').eq(0).click()

--- a/cypress/e2e/filter.spec.ts
+++ b/cypress/e2e/filter.spec.ts
@@ -2,7 +2,7 @@ describe('The correct filter elements should be displayed', () => {
 	before(() => {
 		cy.visit('/catalogue')
 		cy.request('/api/data/catalog.json')
-		// cy.wait(3000)
+		cy.wait(3000)
 	})
 
 	it('renders the filter ', () => {

--- a/cypress/e2e/index.spec.ts
+++ b/cypress/e2e/index.spec.ts
@@ -13,7 +13,6 @@ describe('Access all resources', () => {
 	})
 
 	it('should navigate to the catalog item page on click', () => {
-		// eslint-disable-next-line cypress/no-unnecessary-waiting
 		cy.wait(3000)
 		cy.contains(
 			'Poverty Mapping Rollout Dataset for Timor Leste (2016)'

--- a/cypress/e2e/landing-page.spec.ts
+++ b/cypress/e2e/landing-page.spec.ts
@@ -1,6 +1,3 @@
-/* eslint-disable cypress/no-unnecessary-waiting */
-/* eslint-disable cypress/require-data-selectors */
-
 describe('The correct elements are visible in the landing page', () => {
 	it('renders the main page ', () => {
 		cy.visit('/')

--- a/cypress/e2e/searchbox.spec.ts
+++ b/cypress/e2e/searchbox.spec.ts
@@ -1,0 +1,86 @@
+describe('The search input needs at least 3 characters before displaying search results', () => {
+	it('should not display search results', () => {
+		cy.visit('/')
+		cy.request('/api/data/catalog.json')
+		cy.wait(3000)
+
+		cy.get('input[placeholder="Search for a dataset or a model"]')
+			.click()
+			.type('po')
+
+		cy.contains(
+			'.ant-select-item-option-content',
+			'Poverty Mapping Rollout Dataset for Timor Leste (2016)'
+		).should('not.exist')
+	})
+
+	it('should display search results', () => {
+		cy.visit('/')
+		cy.request('/api/data/catalog.json')
+
+		cy.get('input[placeholder="Search for a dataset or a model"]')
+			.click()
+			.type('pov')
+
+		cy.contains(
+			'.ant-select-item-option-content',
+			'Poverty Mapping Rollout Dataset for Timor Leste (2016)'
+		).should('exist')
+	})
+})
+
+describe('Clicking on a search suggestion should auto-populate the search in the catalogue search page', () => {
+	const searchText = 'Air Quality Model for Thailand'
+
+	it('should populate the search results in catalogue search page', () => {
+		cy.visit('/')
+		cy.request('/api/data/catalog.json')
+
+		cy.get('input[placeholder="Search for a dataset or a model"]')
+			.click()
+			.type('thailand')
+
+		cy.contains('.ant-select-item-option-content', searchText).click()
+
+		cy.location('pathname').should(
+			'eq',
+			`/unicef-ai4d-research-bank/catalogue/airquality-thailand-model`
+		)
+
+		cy.contains('Catalogue').click()
+
+		cy.get('input[placeholder="Search for a dataset or a model"]').should(
+			'have.value',
+			searchText
+		)
+	})
+})
+
+describe('pressing x should clear the search bar', () => {
+	it('should update the search results', () => {
+		cy.visit('/')
+		cy.request('/api/data/catalog.json')
+		cy.visit('/catalogue')
+		cy.get('input[placeholder="Search for a dataset or a model"]')
+			.click()
+			.type('philippines{enter}')
+
+		cy.get('input[placeholder="Search for a dataset or a model"]')
+
+		cy.get('span')
+			.contains('result available')
+			.siblings('div')
+			.find('a')
+			.should('have.length', 1)
+	})
+
+	it('should reset the search results', () => {
+		cy.get('.ant-input-clear-icon').click()
+
+		cy.get('span')
+			.contains('results available')
+			.siblings('div')
+			.find('a')
+			.should('have.length', 5)
+	})
+})

--- a/src/components/CatalogueItemData.tsx
+++ b/src/components/CatalogueItemData.tsx
@@ -140,7 +140,7 @@ const CatalogueItemData = ({ catalogueItem }: Props) => {
 	let dataColumnsSection
 	if (dataColumns) {
 		dataColumnsSection = (
-			<div className='flex flex-col'>
+			<div className='flex flex-col' data-cy='catalog-item-data-schema'>
 				<div className='flex max-h-[500px] flex-col overflow-y-scroll'>
 					<table className='border-collapse'>
 						<thead>

--- a/src/components/FeaturedItemCard.tsx
+++ b/src/components/FeaturedItemCard.tsx
@@ -14,7 +14,7 @@ const FeaturedItemCard = ({ item, image }: Props) => {
 		item['card-type'] === 'model' ? 'MACHINE LEARNING MODEL' : 'DATASET'
 
 	return (
-		<div className='rounded-md border border-gray-300'>
+		<div className='rounded-md border border-gray-300' data-cy='featured-card'>
 			<Link to={`${HOME_PATH}/catalogue/${item.id}`}>
 				<div className='h-[200px]'>
 					<img
@@ -25,10 +25,16 @@ const FeaturedItemCard = ({ item, image }: Props) => {
 					/>
 				</div>
 				<div className='flex flex-col py-3 px-5'>
-					<span className='text-xs text-gray-600'>
+					<span
+						className='text-xs text-gray-600'
+						data-cy='featured-card-org-name'
+					>
 						{item.organization.name}
 					</span>
-					<span className='text-base font-semibold text-cloud-burst'>
+					<span
+						className='text-base font-semibold text-cloud-burst'
+						data-cy='featured-card-name'
+					>
 						{item.name} ({item['year-period']})
 					</span>
 					<div className='flex'>
@@ -47,7 +53,10 @@ const FeaturedItemCard = ({ item, image }: Props) => {
 										fontSize: '14px'
 									}}
 								/>
-								<span className='text-xs text-gray-600'>
+								<span
+									className='text-xs text-gray-600'
+									data-cy='featured-card-country-region'
+								>
 									Country/Region: {formatString(item['country-region'])}
 								</span>
 							</div>
@@ -61,7 +70,10 @@ const FeaturedItemCard = ({ item, image }: Props) => {
 										fontSize: '14px'
 									}}
 								/>
-								<span className='text-xs text-gray-600'>
+								<span
+									className='text-xs text-gray-600'
+									data-cy='featured-card-year-period'
+								>
 									Year/Period: {item['year-period']}
 								</span>
 							</div>

--- a/src/pages/CatalogueItemPage.tsx
+++ b/src/pages/CatalogueItemPage.tsx
@@ -157,7 +157,10 @@ const CatalogueItemPage = () => {
 				<div className='flex w-full flex-col gap-4 p-10 text-cloud-burst md:w-2/3'>
 					<Tabs defaultActiveKey='1' items={tabItems} />
 				</div>
-				<div className='flex w-full flex-col gap-5 p-10 text-cloud-burst md:w-1/3'>
+				<div
+					className='flex w-full flex-col gap-5 p-10 text-cloud-burst md:w-1/3'
+					data-cy='catalog-item-aside'
+				>
 					<div className='rounded bg-gray-50 p-6'>
 						<div className='flex flex-col gap-5'>
 							<div className='align-center flex flex-row gap-3'>
@@ -234,7 +237,10 @@ const CatalogueItemPage = () => {
 							</div>
 						))}
 					</div>
-					<div className='rounded bg-gray-50 p-5'>
+					<div
+						className='bg-gray-50p-5 rounded'
+						data-cy='catalog-item-aside-tags'
+					>
 						<span className='text-sm font-semibold'>
 							<TagsOutlined style={{ marginRight: '8px' }} />
 							Tags

--- a/src/pages/CataloguePage.tsx
+++ b/src/pages/CataloguePage.tsx
@@ -185,7 +185,10 @@ const CataloguePage = () => {
 						<span className='font-semibold text-cloud-burst'>FILTERS</span>
 						<Space style={{ width: '100%' }} direction='vertical'>
 							<div className='pt-3'>
-								<span className='font-bold text-cloud-burst'>
+								<span
+									className='font-bold text-cloud-burst'
+									data-cy='country-filter'
+								>
 									Country/Region
 								</span>
 								<Select


### PR DESCRIPTION
### extra details

- some eslint cypress rules were silenced due to the nature of testing antd components
- actual `catalog.json` file is used as a fixture for tests
- `data-cy` attributes are added to various components / elements in order for easier targeting by the tests

on fixtures: might be a good idea to have a dedicated fixture per sprint, so the backend data to be worked per sprint is more consistent and reliable

### changelist

generally added tests from  [here](https://github.com/thinkingmachines/unicef-ai4d-research-bank/wiki/Frontend-Test-Cases)

- [x] silence 'cypress/no-pause' 'cypress/no-unnecessary-waiting' 'cypress/require-data-selectors' eslint
- [x] add source `catalog.json` file as a possible fixture for cypress tests
- [x] add `data-cy` attributes to various elements
- [x] add  List of dataset and models  tests
- [x] add searchbox tests
- [x] add filters tests
- [x] add featured-dataset tests
- [x] add catalogue item and data schema tests

### how to test

0. Make sure you have cypress installed
1. Run `pnpm merge-catalog`
2. Run `pnpm build`
3. Run `pnpm test:e2e:headless` to run all tests or `pnpm test:e2e` to run the tests via a GUI
4. Assert that all the tests pass