### PR TITLE
fix: add catalogue item hero text color

### DIFF
--- a/src/pages/CatalogueItemPage.tsx
+++ b/src/pages/CatalogueItemPage.tsx
@@ -126,7 +126,7 @@ const CatalogueItemPage = () => {
 
 	return (
 		<div className='min-h-[calc(100vh_-_3rem)] bg-white'>
-			<div className='relative flex min-h-[10rem] flex-col items-center justify-center bg-cloud-burst p-10'>
+			<div className='relative flex min-h-[10rem] flex-col items-center justify-center bg-cloud-burst p-10 text-white'>
 				{detailImage ? (
 					<img
 						src={bannerImage ?? ''}


### PR DESCRIPTION
## Extra details

The font color for the hero banner in the catalogue item page was not explicitly defined which makes the website default to your system defaults i.e. black text for light mode and white text for dark mode.

## Changelog

- [x] Explicitly add text color to hero banner

## How to test

Add a numbered list of steps to make in order to verify that the feature is working. Ideally add a video of you
running the new features you have added. You can use a capturing tool like [ShareX](https://getsharex.com)

1. Set your system to light mode for windows 10 users, you  can search `dark mode` in the start menu search bar and change system color mode in this panel
![image](https://github.com/thinkingmachines/unicef-ai4d-research-bank/assets/122899250/a12cb451-0793-440d-acae-8eec908fa430)

2. Go to home page and click on a featured dataset
3. Assert that the text color for the hero banner is white
4. Repeat for a dark mode system
![image](https://github.com/thinkingmachines/unicef-ai4d-research-bank/assets/122899250/1616b7d5-e5f4-4bc2-8b58-b06da0564c3d)
