### PR TITLE
chore:Add manual triggering of github actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,9 @@ name: Deploy-GH-Pages
 on:
   push:
     branches: [main]
+
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - 'catalog/**.yml'
 
+  workflow_dispatch:
+
 jobs:
   validate-catalog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Add manual triggering of github actions
- chore: update gh actions

## Extra details
- enable manual workflow trigger of catalog item validation and deploy actions so they can be triggered via the gh actions web ui.

## Changelog

- update the deploy and validate gh actions.

## How to test

0. Go to [deploy](https://github.com/thinkingmachines/unicef-ai4d-research-bank/actions/workflows/deploy.yml) and [validate](https://github.com/thinkingmachines/unicef-ai4d-research-bank/actions/workflows/validate.yml) actions screen

1. There should be a `Run workflow` button to allow the manual triggering of the workflow
2. Click on `Run workflow` button to trigger the workflow manually 
