### PR TITLE
chore: add fixtures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Validate unit tests
         run: pnpm test:ci
 
-      - name: Build prod
-        run: pnpm build
+      - name: Build test environment
+        run: pnpm build:test-env
 
       - name: Validate e2e
         run: pnpm test:e2e:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,11 +32,6 @@ jobs:
       - name: Install dependencies
         run: pnpm i && pnpm cypress install && cp .env.github .env
 
-      - name: Merge catalog entries
-        run: python scripts/transform_catalog.py && python scripts/transform_featured.py
-        env:
-          GSTORAGE_API_KEY: ${{ secrets.GSTORAGE_API_KEY }}
-
       - name: Validate format
         run: pnpm run-p lint
 

--- a/cypress/e2e/catalog-item.spec.ts
+++ b/cypress/e2e/catalog-item.spec.ts
@@ -1,7 +1,6 @@
 describe('The catalog item sub components display correctly', () => {
 	before(() => {
 		cy.visit('/')
-		cy.request('/api/data/catalog.json')
 		cy.wait(3000)
 	})
 
@@ -59,7 +58,6 @@ describe('The catalog item sub components display correctly', () => {
 describe('The data columns should render correctly', () => {
 	before(() => {
 		cy.visit('/')
-		cy.request('/api/data/catalog.json')
 		cy.wait(3000)
 	})
 

--- a/cypress/e2e/catalog-page.spec.ts
+++ b/cypress/e2e/catalog-page.spec.ts
@@ -1,5 +1,3 @@
-import type { CatalogueItemType } from '../../src/types/CatalogueItem.type'
-
 describe('The catalog page renders', () => {
 	before(() => {
 		cy.visit('/catalogue')
@@ -43,51 +41,23 @@ describe('The catalog page renders', () => {
 })
 
 describe('all models and datasets should be displayed by default', () => {
-	let catalogDataLength: number
-
-	before(() => {
-		cy.fixture('catalog.json').then((data: CatalogueItemType[]) => {
-			catalogDataLength = data.length
-		})
-	})
-
 	it('should render all the default items', () => {
 		cy.visit('/')
 
 		cy.contains('Catalogue').click()
 		cy.location('pathname').should('eq', `/unicef-ai4d-research-bank/catalogue`)
 
-		if (catalogDataLength > 5) {
-			cy.get('span')
-				.contains('results available')
-				.siblings('div')
-				.find('a')
-				.should('have.length', 5)
-		} else {
-			cy.get('span')
-				.contains('results available')
-				.siblings('div')
-				.find('a')
-				.should('have.length', catalogDataLength)
-		}
+		cy.get('span')
+			.contains('results available')
+			.siblings('div')
+			.find('a')
+			.should('have.length', 5)
 	})
 })
 
 describe('clicking on a search result should redirect the user to the selected catalogue item page', () => {
-	let catalogData: CatalogueItemType[]
-
-	before(() => {
-		cy.fixture('catalog.json').then((data: CatalogueItemType[]) => {
-			catalogData = data
-		})
-	})
-
 	it('renders the main page ', () => {
 		cy.visit('/')
-	})
-
-	it('fetch the catalog json file ', () => {
-		cy.request('/api/data/catalog.json')
 	})
 
 	it('should navigate to the catalog page on click', () => {
@@ -101,11 +71,9 @@ describe('clicking on a search result should redirect the user to the selected c
 			.first()
 			.click()
 
-		cy.log(catalogData[0].id)
-
 		cy.location('pathname').should(
 			'eq',
-			`/unicef-ai4d-research-bank/catalogue/${catalogData[0].id}`
+			`/unicef-ai4d-research-bank/catalogue/povmap-philippines`
 		)
 	})
 })

--- a/cypress/e2e/catalog-page.spec.ts
+++ b/cypress/e2e/catalog-page.spec.ts
@@ -1,7 +1,6 @@
 describe('The catalog page renders', () => {
 	before(() => {
 		cy.visit('/catalogue')
-		cy.request('/api/data/catalog.json')
 		cy.wait(3000)
 	})
 

--- a/cypress/e2e/featured-dataset.spec.ts
+++ b/cypress/e2e/featured-dataset.spec.ts
@@ -1,13 +1,11 @@
 describe('There should only be a maximum of 3 featured datasets', () => {
 	before(() => {
 		cy.visit('/catalogue')
-		cy.request('/api/data/catalog.json')
 		cy.wait(3000)
 	})
 
 	it('should display 3 dataset cards', () => {
 		cy.visit('/')
-		cy.request('/api/data/catalog.json')
 
 		cy.get('[data-cy="featured-card"]').its('length').should('eq', 3)
 	})
@@ -16,27 +14,23 @@ describe('There should only be a maximum of 3 featured datasets', () => {
 describe('The featured cards should display the correct sub components', () => {
 	before(() => {
 		cy.visit('/catalogue')
-		cy.request('/api/data/catalog.json')
 		cy.wait(3000)
 	})
 
 	it('should display the org name', () => {
 		cy.visit('/')
-		cy.request('/api/data/catalog.json')
 
 		cy.get('[data-cy="featured-card-org-name"]').its('length').should('eq', 3)
 	})
 
 	it('should display the card name', () => {
 		cy.visit('/')
-		cy.request('/api/data/catalog.json')
 
 		cy.get('[data-cy="featured-card-name"]').its('length').should('eq', 3)
 	})
 
 	it('should display the country-region name', () => {
 		cy.visit('/')
-		cy.request('/api/data/catalog.json')
 
 		cy.get('[data-cy="featured-card-country-region"]')
 			.its('length')
@@ -45,7 +39,6 @@ describe('The featured cards should display the correct sub components', () => {
 
 	it('should display the year/period', () => {
 		cy.visit('/')
-		cy.request('/api/data/catalog.json')
 
 		cy.get('[data-cy="featured-card-year-period"]')
 			.its('length')
@@ -54,15 +47,8 @@ describe('The featured cards should display the correct sub components', () => {
 })
 
 describe('Clicking on a featured dataset should redirect to the catalogue item page', () => {
-	before(() => {
-		cy.visit('/catalogue')
-		cy.request('/api/data/catalog.json')
-		cy.wait(3000)
-	})
-
 	it('should redirect to the catalogue id page with the same id as the featured dataset', () => {
 		cy.visit('/')
-		cy.request('/api/data/catalog.json')
 
 		cy.contains('Air Quality Model for Thailand').click()
 

--- a/cypress/e2e/filter.spec.ts
+++ b/cypress/e2e/filter.spec.ts
@@ -1,7 +1,6 @@
 describe('The correct filter elements should be displayed', () => {
 	before(() => {
 		cy.visit('/catalogue')
-		cy.request('/api/data/catalog.json')
 		cy.wait(3000)
 	})
 

--- a/cypress/e2e/filter.spec.ts
+++ b/cypress/e2e/filter.spec.ts
@@ -88,7 +88,7 @@ describe('The search entries should only entries from year 2017 till present', (
 
 		cy.contains('.ant-picker-cell-inner', '2017').first().click()
 
-		cy.contains('3 results available').should('be.visible')
+		cy.contains('2 results available').should('be.visible')
 	})
 })
 
@@ -102,7 +102,7 @@ describe('The search entries should only entries from before year 2019', () => {
 
 		cy.contains('.ant-picker-cell-inner', '2019').first().click()
 
-		cy.contains('5 results available').should('be.visible')
+		cy.contains('4 results available').should('be.visible')
 	})
 })
 

--- a/cypress/e2e/index.spec.ts
+++ b/cypress/e2e/index.spec.ts
@@ -3,10 +3,6 @@ describe('Access all resources', () => {
 		cy.visit('/')
 	})
 
-	it('fetch the catalog json file ', () => {
-		cy.request('/api/data/catalog.json')
-	})
-
 	it('should navigate to the catalog page on click', () => {
 		cy.contains('Catalogue').click()
 		cy.location('pathname').should('eq', `/unicef-ai4d-research-bank/catalogue`)

--- a/cypress/e2e/landing-page.spec.ts
+++ b/cypress/e2e/landing-page.spec.ts
@@ -3,9 +3,7 @@ describe('The correct elements are visible in the landing page', () => {
 		cy.visit('/')
 	})
 
-	it('fetch the catalog json file ', () => {
-		cy.request('/api/data/catalog.json')
-	})
+	it('fetch the catalog json file ', () => {})
 
 	it('renders the hero', () => {
 		cy.get('[data-cy="hero-mainText"]').contains(
@@ -44,7 +42,6 @@ describe('Clicking the "browse by tags" auto populate the catalogue filters', ()
 	})
 
 	it('redirects to the search catalogue page', () => {
-		cy.request('/api/data/catalog.json')
 		cy.contains('button', 'air-quality').click()
 		cy.location('pathname').should('eq', `/unicef-ai4d-research-bank/catalogue`)
 	})

--- a/cypress/e2e/searchbox.spec.ts
+++ b/cypress/e2e/searchbox.spec.ts
@@ -1,7 +1,6 @@
 describe('The search input needs at least 3 characters before displaying search results', () => {
 	it('should not display search results', () => {
 		cy.visit('/')
-		cy.request('/api/data/catalog.json')
 		cy.wait(3000)
 
 		cy.get('input[placeholder="Search for a dataset or a model"]')
@@ -16,7 +15,6 @@ describe('The search input needs at least 3 characters before displaying search 
 
 	it('should display search results', () => {
 		cy.visit('/')
-		cy.request('/api/data/catalog.json')
 
 		cy.get('input[placeholder="Search for a dataset or a model"]')
 			.click()
@@ -34,7 +32,6 @@ describe('Clicking on a search suggestion should auto-populate the search in the
 
 	it('should populate the search results in catalogue search page', () => {
 		cy.visit('/')
-		cy.request('/api/data/catalog.json')
 
 		cy.get('input[placeholder="Search for a dataset or a model"]')
 			.click()
@@ -59,7 +56,6 @@ describe('Clicking on a search suggestion should auto-populate the search in the
 describe('pressing x should clear the search bar', () => {
 	it('should update the search results', () => {
 		cy.visit('/')
-		cy.request('/api/data/catalog.json')
 		cy.visit('/catalogue')
 		cy.get('input[placeholder="Search for a dataset or a model"]')
 			.click()

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"version": "0.0.1",
 	"scripts": {
 		"build": "vite build",
+		"build:test-env": "NODE_ENV=test vite build",
 		"commit": "cz",
 		"dev": "vite --open",
 		"prepare": "husky install",

--- a/public/api/data/fixtures/catalog.json
+++ b/public/api/data/fixtures/catalog.json
@@ -1,0 +1,3402 @@
+[
+	{
+		"name": "Poverty Mapping Model for Philippines",
+		"description": "This is an sklearn Random Forest regressor model for predicting relative wealth for Philippines. Through a post-training binning process, the model also predicts a quintile-grouped relative wealth category ('A' to 'E')  It is a single-country model trained on open datasets from Earth Observation Group (EOG) nightlights data, Open Streetmap (OSM) Points of Interest (POI) data, Ookla internet speed data as well as Domestic and Health Survey (DHS) data from USAID.  It was built as part of the UNICEF AI4D Poverty Mapping Project which aims to develop open datasets and machine learning (ML) models for poverty mapping estimation across nine countries  in Southeast Asia (SEA).\n",
+		"card-type": "model",
+		"organization": {
+			"name": "Thinking Machines Data Sciences Inc",
+			"url": "https://thinkingmachin.es"
+		},
+		"date-added": "2023-03-02",
+		"tags": ["poverty-mapping", "philippines"],
+		"country-region": ["philippines"],
+		"year-period": 2017,
+		"evaluation-metrics": [
+			{
+				"metric": {
+					"metric-type": "rsquared",
+					"value": 0.59
+				},
+				"link": {
+					"description": "Model evaluation using cross-validation",
+					"url": "https://thinkingmachines.github.io/unicef-ai4d-poverty-mapping/notebooks/2023-01-17-initial-model-ph-mm-tl-kh/model_ph.html#evaluate-model-training-using-cross-validation"
+				}
+			},
+			{
+				"link": {
+					"description": "SHAP Feature Importance Plots",
+					"url": "https://thinkingmachines.github.io/unicef-ai4d-poverty-mapping/notebooks/2023-01-17-initial-model-ph-mm-tl-kh/model_ph.html#shap-feature-importance"
+				}
+			}
+		],
+		"links": [
+			{
+				"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping",
+				"description": "UNICEF AI4D Poverty Mapping Project Github Repository",
+				"type": "repository"
+			},
+			{
+				"url": "https://drive.google.com/file/d/1MlE5VJTWwAdQlpyFcVYku8s4efIpxtrB/view?usp=share_link",
+				"description": "Philippines Poverty Mapping Model Weights (.pkl). See related notebook links for usage",
+				"type": "model-weights"
+			},
+			{
+				"url": "https://www.googleapis.com/drive/v3/files/14i_k2xhnuuVkQJJL9Mt8l3QhzLDDOtXQ?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+				"description": "Country wide rollout (inference) of the Poverty Mapping Model on Philippines using 2.4km grids (bingtile quadkey level 14)",
+				"type": "dataset-raw-csv",
+				"alt-format": [
+					{
+						"url": "https://www.googleapis.com/drive/v3/files/14i_k2xhnuuVkQJJL9Mt8l3QhzLDDOtXQ?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+						"type": "dataset-raw-csv"
+					},
+					{
+						"url": "https://www.googleapis.com/drive/v3/files/1HVfLJiY1UmA7tWW4XO_xjpQrszmTJTHg?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+						"type": "dataset-raw-geojson"
+					}
+				],
+				"name": "2023-02-21-ph-rollout-output.csv"
+			},
+			{
+				"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/ph/1_ph_train_model.ipynb",
+				"description": "Philippines Model Rollout Part 1 (Train Model)",
+				"type": "code-notebook"
+			},
+			{
+				"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/ph/2_ph_generate_grids.ipynb",
+				"description": "Philippines Model Rollout Part 2 (Generate Grids)",
+				"type": "code-notebook"
+			},
+			{
+				"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/ph/3_ph_rollout_model.ipynb",
+				"description": "Philippines Model Rollout Part 3 (Rollout Model)",
+				"type": "code-notebook"
+			},
+			{
+				"url": "https://www.googleapis.com/drive/v3/files/15q-fTiTI-oN_aYKwiXhgzdx4fyTa3Y07?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+				"description": "Training dataset for Poverty Mapping Model on Philippines",
+				"type": "training-dataset-csv",
+				"name": "2023-02-21-ph-dhs-cluster-features-all",
+				"alt-format": [
+					{
+						"url": "https://www.googleapis.com/drive/v3/files/15q-fTiTI-oN_aYKwiXhgzdx4fyTa3Y07?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+						"type": "training-dataset-csv"
+					}
+				]
+			}
+		],
+		"id": "povmap-philippines",
+		"data-columns": [
+			{
+				"name": "quadkey",
+				"type": "integer",
+				"hxltag": "#geo+code+v_quadkeys"
+			},
+			{
+				"name": "shapeName",
+				"type": "string",
+				"hxltag": "#adm2+name"
+			},
+			{
+				"name": "shapeISO",
+				"type": "float64"
+			},
+			{
+				"name": "shapeID",
+				"type": "string",
+				"hxltag": "#adm2+code+v_pcodes"
+			},
+			{
+				"name": "shapeGroup",
+				"type": "string",
+				"hxltag": "#adm0+code+v_pcodes"
+			},
+			{
+				"name": "shapeType",
+				"type": "string"
+			},
+			{
+				"name": "pop_count",
+				"type": "float64",
+				"hxltag": "#population"
+			},
+			{
+				"name": "Predicted Relative Wealth Index",
+				"type": "float64"
+			},
+			{
+				"name": "Predicted Wealth Category (quintile)",
+				"type": "string"
+			},
+			{
+				"name": "poi_count",
+				"type": "float64"
+			},
+			{
+				"name": "atm_count",
+				"type": "float64"
+			},
+			{
+				"name": "atm_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "bank_count",
+				"type": "float64"
+			},
+			{
+				"name": "bank_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "bus_station_count",
+				"type": "float64"
+			},
+			{
+				"name": "bus_station_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "cafe_count",
+				"type": "float64"
+			},
+			{
+				"name": "cafe_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "charging_station_count",
+				"type": "float64"
+			},
+			{
+				"name": "charging_station_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "courthouse_count",
+				"type": "float64"
+			},
+			{
+				"name": "courthouse_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "dentist_count",
+				"type": "float64"
+			},
+			{
+				"name": "dentist_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "fast_food_count",
+				"type": "float64"
+			},
+			{
+				"name": "fast_food_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "fire_station_count",
+				"type": "float64"
+			},
+			{
+				"name": "fire_station_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "food_court_count",
+				"type": "float64"
+			},
+			{
+				"name": "food_court_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "fuel_count",
+				"type": "float64"
+			},
+			{
+				"name": "fuel_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "hospital_count",
+				"type": "float64"
+			},
+			{
+				"name": "hospital_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "library_count",
+				"type": "float64"
+			},
+			{
+				"name": "library_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "marketplace_count",
+				"type": "float64"
+			},
+			{
+				"name": "marketplace_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "pharmacy_count",
+				"type": "float64"
+			},
+			{
+				"name": "pharmacy_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "police_count",
+				"type": "float64"
+			},
+			{
+				"name": "police_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "post_box_count",
+				"type": "float64"
+			},
+			{
+				"name": "post_box_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "post_office_count",
+				"type": "float64"
+			},
+			{
+				"name": "post_office_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "restaurant_count",
+				"type": "float64"
+			},
+			{
+				"name": "restaurant_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "social_facility_count",
+				"type": "float64"
+			},
+			{
+				"name": "social_facility_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "supermarket_count",
+				"type": "float64"
+			},
+			{
+				"name": "supermarket_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "townhall_count",
+				"type": "float64"
+			},
+			{
+				"name": "townhall_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "road_count",
+				"type": "float64"
+			},
+			{
+				"name": "fixed_2019_mean_avg_d_kbps_mean",
+				"type": "float64"
+			},
+			{
+				"name": "fixed_2019_mean_avg_u_kbps_mean",
+				"type": "float64"
+			},
+			{
+				"name": "fixed_2019_mean_avg_lat_ms_mean",
+				"type": "float64"
+			},
+			{
+				"name": "fixed_2019_mean_num_tests_mean",
+				"type": "float64"
+			},
+			{
+				"name": "fixed_2019_mean_num_devices_mean",
+				"type": "float64"
+			},
+			{
+				"name": "mobile_2019_mean_avg_d_kbps_mean",
+				"type": "float64"
+			},
+			{
+				"name": "mobile_2019_mean_avg_u_kbps_mean",
+				"type": "float64"
+			},
+			{
+				"name": "mobile_2019_mean_avg_lat_ms_mean",
+				"type": "float64"
+			},
+			{
+				"name": "mobile_2019_mean_num_tests_mean",
+				"type": "float64"
+			},
+			{
+				"name": "mobile_2019_mean_num_devices_mean",
+				"type": "float64"
+			},
+			{
+				"name": "avg_rad_min",
+				"type": "float64"
+			},
+			{
+				"name": "avg_rad_max",
+				"type": "float64"
+			},
+			{
+				"name": "avg_rad_mean",
+				"type": "float64"
+			},
+			{
+				"name": "avg_rad_std",
+				"type": "float64"
+			},
+			{
+				"name": "avg_rad_median",
+				"type": "float64"
+			},
+			{
+				"name": "geometry",
+				"type": "string",
+				"hxltag": "#geo+bounds"
+			}
+		],
+		"sample-data": [
+			[
+				"#geo+code+v_quadkeys",
+				"#adm2+name",
+				"",
+				"#adm2+code+v_pcodes",
+				"#adm0+code+v_pcodes",
+				"",
+				"#population",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"#geo+bounds"
+			],
+			[
+				"13232122010020",
+				"Tawi-Tawi",
+				"None",
+				"PHL-ADM2-3_0_0-B77",
+				"PHL",
+				"ADM2",
+				"11.67798",
+				"0.13520973290615726",
+				"E",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"1.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.058928702026605606",
+				"0.011213013902306557",
+				"-0.025149547391467623",
+				"0.013619571772728838",
+				"-0.025510676205158234",
+				"POLYGON ((118.47656250000001 6.948238638117006, 118.47656250000001 6.970049417296233, 118.49853515624999 6.970049417296233, 118.49853515624999 6.948238638117006, 118.47656250000001 6.948238638117006))"
+			],
+			[
+				"13232120223323",
+				"Tawi-Tawi",
+				"None",
+				"PHL-ADM2-3_0_0-B77",
+				"PHL",
+				"ADM2",
+				"317.069037",
+				"0.15715275878856277",
+				"E",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"1.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.0706019178032875",
+				"0.02426302060484886",
+				"-0.018043290376663208",
+				"0.019217792027127607",
+				"-0.019475704059004784",
+				"POLYGON ((118.41064453125 7.013667927566638, 118.41064453125 7.035475652433014, 118.43261718750001 7.035475652433014, 118.43261718750001 7.013667927566638, 118.41064453125 7.013667927566638))"
+			],
+			[
+				"13232122001101",
+				"Tawi-Tawi",
+				"None",
+				"PHL-ADM2-3_0_0-B77",
+				"PHL",
+				"ADM2",
+				"253.0818",
+				"0.14345787775929694",
+				"E",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"2.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.05380287766456604",
+				"0.009381614625453949",
+				"-0.01253371000289917",
+				"0.014730552945183387",
+				"-0.015220651403069496",
+				"POLYGON ((118.41064453125 6.991859181483679, 118.41064453125 7.013667927566638, 118.43261718750001 7.013667927566638, 118.43261718750001 6.991859181483679, 118.41064453125 6.991859181483679))"
+			],
+			[
+				"13232122001103",
+				"Tawi-Tawi",
+				"None",
+				"PHL-ADM2-3_0_0-B77",
+				"PHL",
+				"ADM2",
+				"27.250587",
+				"0.14554000625379854",
+				"E",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.08343401551246643",
+				"-0.008117091841995716",
+				"-0.04223332405090332",
+				"0.01825951557811232",
+				"-0.04466962441802025",
+				"POLYGON ((118.41064453125 6.970049417296233, 118.41064453125 6.991859181483679, 118.43261718750001 6.991859181483679, 118.43261718750001 6.970049417296233, 118.41064453125 6.970049417296233))"
+			],
+			[
+				"13232120223332",
+				"Tawi-Tawi",
+				"None",
+				"PHL-ADM2-3_0_0-B77",
+				"PHL",
+				"ADM2",
+				"763.870501",
+				"0.15914390655754548",
+				"E",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"2.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.054072968661785126",
+				"0.018787557259202003",
+				"-0.009383666515350341",
+				"0.018987514095642002",
+				"-0.009585214778780937",
+				"POLYGON ((118.43261718750001 7.013667927566638, 118.43261718750001 7.035475652433014, 118.45458984375 7.035475652433014, 118.45458984375 7.013667927566638, 118.43261718750001 7.013667927566638))"
+			],
+			[
+				"13232122001110",
+				"Tawi-Tawi",
+				"None",
+				"PHL-ADM2-3_0_0-B77",
+				"PHL",
+				"ADM2",
+				"737.818667",
+				"0.15022882971000248",
+				"E",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"4.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.04809705913066864",
+				"0.032275792211294174",
+				"-0.0081044203042984",
+				"0.01807023625310171",
+				"-0.004992029629647732",
+				"POLYGON ((118.43261718750001 6.991859181483679, 118.43261718750001 7.013667927566638, 118.45458984375 7.013667927566638, 118.45458984375 6.991859181483679, 118.43261718750001 6.991859181483679))"
+			],
+			[
+				"13232122001112",
+				"Tawi-Tawi",
+				"None",
+				"PHL-ADM2-3_0_0-B77",
+				"PHL",
+				"ADM2",
+				"475.195466",
+				"0.16485235231949746",
+				"E",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"1.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.055117372423410416",
+				"0.0725533664226532",
+				"-0.008412790298461915",
+				"0.029636549553036944",
+				"-0.019500423222780228",
+				"POLYGON ((118.43261718750001 6.970049417296233, 118.43261718750001 6.991859181483679, 118.45458984375 6.991859181483679, 118.45458984375 6.970049417296233, 118.43261718750001 6.970049417296233))"
+			],
+			[
+				"13232120223333",
+				"Tawi-Tawi",
+				"None",
+				"PHL-ADM2-3_0_0-B77",
+				"PHL",
+				"ADM2",
+				"2120.725562",
+				"0.15206763736842485",
+				"E",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"3.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.020981281995773315",
+				"0.03218582645058632",
+				"0.0060047519207000735",
+				"0.012290202635864115",
+				"0.007257502526044846",
+				"POLYGON ((118.45458984375 7.013667927566638, 118.45458984375 7.035475652433014, 118.47656250000001 7.035475652433014, 118.47656250000001 7.013667927566638, 118.45458984375 7.013667927566638))"
+			],
+			[
+				"13232122001111",
+				"Tawi-Tawi",
+				"None",
+				"PHL-ADM2-3_0_0-B77",
+				"PHL",
+				"ADM2",
+				"1245.499815",
+				"0.13520973290615726",
+				"E",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"1.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.022179236635565758",
+				"0.023665664717555046",
+				"0.003340056836605072",
+				"0.013556809080011547",
+				"0.0031797944102436304",
+				"POLYGON ((118.45458984375 6.991859181483679, 118.45458984375 7.013667927566638, 118.47656250000001 7.013667927566638, 118.47656250000001 6.991859181483679, 118.45458984375 6.991859181483679))"
+			]
+		],
+		"detail-image-url": "assets/items/povmap-philippines.png"
+	},
+	{
+		"name": "Air Quality Model for Thailand",
+		"description": "This project explored PM2.5 estimation using Machine Learning models in Thailand. Air pollution is a pressing health concern worldwide, and thus, its monitoring is important for epidemological studies and informing public policy. However, ground sensors (whether reference grade or low-cost) are sparse. For example, in Mueang Chiang Mai, there are only a few air quality sensors based on OpenAQ data. Using Machine Learning models to predict PM2.5 levels based on area predictors is a potential way to augment these ground stations, and allows us to monitor air quality even in areas without them.\n",
+		"card-type": "model",
+		"organization": {
+			"name": "Unicef East Asia and Pacific Regional Office",
+			"url": "https://www.unicef.org/eap/"
+		},
+		"date-added": "2021-03-02",
+		"tags": ["air-quality", "thailand", "machine-learning"],
+		"country-region": ["thailand"],
+		"year-period": "2020-2023",
+		"evaluation-metrics": [
+			{
+				"link": {
+					"description": "Manuscript - see Section 3.3 Evaluation and Metrics",
+					"url": "https://drive.google.com/file/d/1lzGiUWpQ_vzyvY9FfDjWEH21Hiu-H9lz/view"
+				}
+			}
+		],
+		"links": [
+			{
+				"url": "https://www.googleapis.com/drive/v3/files/138zqndK07bqtUXAelzpiFqacohVxWetx?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+				"description": "air quality predictions for chiangmai for the year 2021\n",
+				"type": "dataset-raw-csv",
+				"name": "predictions_chiangmai_2021.csv",
+				"alt-format": [
+					{
+						"url": "https://www.googleapis.com/drive/v3/files/138zqndK07bqtUXAelzpiFqacohVxWetx?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+						"type": "dataset-raw-csv"
+					}
+				]
+			},
+			{
+				"url": "https://www.googleapis.com/drive/v3/files/13-wFFCCntJsLQVmyFE8Cm7Wf1dmCw2pd?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+				"description": "Table generated from OpenAQ PM2.5 values.This file also contains the same columns as the air4thai one, but with the additional sensor_type column. This indicated which type of sensor was used to measure PM2.5 value in each station per day. This is the latest, best dataset we have for ML modelling. The other datasets were preserved for replicating the experiments.\n",
+				"type": "training-dataset-csv",
+				"name": "2022-05-18-base-table-openaq-filt.csv",
+				"alt-format": [
+					{
+						"url": "https://www.googleapis.com/drive/v3/files/13-wFFCCntJsLQVmyFE8Cm7Wf1dmCw2pd?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+						"type": "training-dataset-csv"
+					}
+				]
+			},
+			{
+				"url": "https://www.googleapis.com/drive/v3/files/12wz-BgJChgWZZyAZ97vZ6uwXPffDT2kQ?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+				"description": "Derivation of 2022-05-18-base-table-openaq-filt, filtering observations to sensor_type == \"reference grade\"\n",
+				"type": "training-dataset-csv",
+				"name": "2022-05-31-base-table-openaq-refgrade.csv",
+				"alt-format": [
+					{
+						"url": "https://www.googleapis.com/drive/v3/files/12wz-BgJChgWZZyAZ97vZ6uwXPffDT2kQ?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+						"type": "training-dataset-csv"
+					}
+				]
+			},
+			{
+				"url": "https://www.googleapis.com/drive/v3/files/134uGLrh3kGuymEqsM_b0jQT8InIwMWB-?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+				"description": "Derivation of 2022-05-18-base-table-openaq-filt, filtering observations to sensor_type == \"low cost\"\n",
+				"type": "training-dataset-csv",
+				"name": "2022-05-31-base-table-openaq-lowcost.csv",
+				"alt-format": [
+					{
+						"url": "https://www.googleapis.com/drive/v3/files/134uGLrh3kGuymEqsM_b0jQT8InIwMWB-?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+						"type": "training-dataset-csv"
+					}
+				]
+			},
+			{
+				"url": "https://www.googleapis.com/drive/v3/files/1kxScRmolAA5hSd6Ig1ly85WQJ_Z6NmGc?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+				"description": "Table patched from the sub-regression model experiment. Missing MAIAC AOD values were predicted using a model trained using CAM AOD data.  These predictions were appended to the existing AOD data used for training the AOD model.  This patched table was then used to predict PM 2.5 values\n",
+				"type": "training-dataset-csv",
+				"name": "2022-05-31-patched-table-hxl-tagged-openaq.csv",
+				"alt-format": [
+					{
+						"url": "https://www.googleapis.com/drive/v3/files/1kxScRmolAA5hSd6Ig1ly85WQJ_Z6NmGc?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+						"type": "training-dataset-csv"
+					}
+				]
+			},
+			{
+				"url": "https://github.com/thinkingmachines/unicef-ai4d-air-quality",
+				"description": "UNICEF AI4D Air Quality Github Repository",
+				"type": "repository"
+			},
+			{
+				"url": "https://drive.google.com/file/d/1lzGiUWpQ_vzyvY9FfDjWEH21Hiu-H9lz/view",
+				"description": "Modelling of Daily PM2.5 in Thailand using Machine Learning on Remote Sensing Datasets",
+				"type": "research-paper"
+			},
+			{
+				"url": "https://drive.google.com/file/d/1lzGiUWpQ_vzyvY9FfDjWEH21Hiu-H9lz/view",
+				"description": "Limitations of using the model",
+				"type": "limitations"
+			}
+		],
+		"id": "airquality-thailand-model",
+		"data-columns": [
+			{
+				"name": "date",
+				"type": "string",
+				"hxltag": "#date"
+			},
+			{
+				"name": "id",
+				"type": "integer"
+			},
+			{
+				"name": "longitude",
+				"type": "float64",
+				"hxltag": "#geo+lon"
+			},
+			{
+				"name": "latitude",
+				"type": "float64",
+				"hxltag": "#geo+lat"
+			},
+			{
+				"name": "total_population",
+				"type": "float64",
+				"hxltag": "#population"
+			},
+			{
+				"name": "AAI_mean",
+				"type": "float64"
+			},
+			{
+				"name": "AAI_min",
+				"type": "float64"
+			},
+			{
+				"name": "AAI_max",
+				"type": "float64"
+			},
+			{
+				"name": "AAI_median",
+				"type": "float64"
+			},
+			{
+				"name": "CAMS_AOD_055_mean",
+				"type": "float64"
+			},
+			{
+				"name": "CAMS_AOD_055_min",
+				"type": "float64"
+			},
+			{
+				"name": "CAMS_AOD_055_max",
+				"type": "float64"
+			},
+			{
+				"name": "CAMS_AOD_055_median",
+				"type": "float64"
+			},
+			{
+				"name": "NDVI_mean",
+				"type": "float64"
+			},
+			{
+				"name": "NDVI_min",
+				"type": "float64"
+			},
+			{
+				"name": "NDVI_max",
+				"type": "float64"
+			},
+			{
+				"name": "NDVI_median",
+				"type": "float64"
+			},
+			{
+				"name": "EVI_mean",
+				"type": "float64"
+			},
+			{
+				"name": "EVI_min",
+				"type": "float64"
+			},
+			{
+				"name": "EVI_max",
+				"type": "float64"
+			},
+			{
+				"name": "EVI_median",
+				"type": "float64"
+			},
+			{
+				"name": "dewpoint_temperature_2m_mean",
+				"type": "float64"
+			},
+			{
+				"name": "dewpoint_temperature_2m_min",
+				"type": "float64"
+			},
+			{
+				"name": "dewpoint_temperature_2m_median",
+				"type": "float64"
+			},
+			{
+				"name": "dewpoint_temperature_2m_max",
+				"type": "float64"
+			},
+			{
+				"name": "temperature_2m_mean",
+				"type": "float64"
+			},
+			{
+				"name": "temperature_2m_min",
+				"type": "float64"
+			},
+			{
+				"name": "temperature_2m_median",
+				"type": "float64"
+			},
+			{
+				"name": "temperature_2m_max",
+				"type": "float64"
+			},
+			{
+				"name": "u_component_of_wind_10m_mean",
+				"type": "float64"
+			},
+			{
+				"name": "u_component_of_wind_10m_min",
+				"type": "float64"
+			},
+			{
+				"name": "u_component_of_wind_10m_median",
+				"type": "float64"
+			},
+			{
+				"name": "u_component_of_wind_10m_max",
+				"type": "float64"
+			},
+			{
+				"name": "v_component_of_wind_10m_mean",
+				"type": "float64"
+			},
+			{
+				"name": "v_component_of_wind_10m_min",
+				"type": "float64"
+			},
+			{
+				"name": "v_component_of_wind_10m_median",
+				"type": "float64"
+			},
+			{
+				"name": "v_component_of_wind_10m_max",
+				"type": "float64"
+			},
+			{
+				"name": "surface_pressure_mean",
+				"type": "float64"
+			},
+			{
+				"name": "surface_pressure_min",
+				"type": "float64"
+			},
+			{
+				"name": "surface_pressure_median",
+				"type": "float64"
+			},
+			{
+				"name": "surface_pressure_max",
+				"type": "float64"
+			},
+			{
+				"name": "total_precipitation_daily",
+				"type": "float64"
+			},
+			{
+				"name": "mean_precipitation_hourly",
+				"type": "float64"
+			},
+			{
+				"name": "predicted_pm2.5",
+				"type": "float64"
+			}
+		],
+		"sample-data": [
+			[
+				"#date",
+				"",
+				"#geo+lon",
+				"#geo+lat",
+				"#population",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				""
+			],
+			[
+				"2021-01-01",
+				"111",
+				"98.9110741636266",
+				"18.8290518229066",
+				"16.220223",
+				"-0.6838250149948155",
+				"-0.6838250149948155",
+				"-0.6838250149948155",
+				"-0.6838250149948155",
+				"341.93001396772337",
+				"227.88545489311215",
+				"575.1596093177795",
+				"320.63983380794525",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"284.22791290283203",
+				"282.73199462890625",
+				"284.1984405517578",
+				"286.28533935546875",
+				"291.3379185994466",
+				"285.74610900878906",
+				"290.7573471069336",
+				"296.4067687988281",
+				"-0.5070650180180868",
+				"-1.1557846069335938",
+				"-0.4557218551635742",
+				"0.1714019775390625",
+				"0.1882222493489583",
+				"-0.75714111328125",
+				"0.2413864135742187",
+				"1.138153076171875",
+				"93865.85384114584",
+				"93680.296875",
+				"93858.671875",
+				"94132.625",
+				"0.0",
+				"0.0",
+				"91.67307"
+			],
+			[
+				"2021-01-02",
+				"111",
+				"98.9110741636266",
+				"18.8290518229066",
+				"16.220223",
+				"-1.7944247722637272",
+				"-1.7944247722637272",
+				"-1.7944247722637272",
+				"-1.7944247722637272",
+				"340.6332983839803",
+				"207.6076865196228",
+				"503.8345456123352",
+				"334.82131361961365",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"283.39222526550293",
+				"282.1583709716797",
+				"283.15442657470703",
+				"285.17579650878906",
+				"291.24835713704425",
+				"285.05841064453125",
+				"291.1985397338867",
+				"297.18096923828125",
+				"-0.2797364791234334",
+				"-0.7048416137695312",
+				"-0.2138624191284179",
+				"0.08819580078125",
+				"0.1177033185958862",
+				"-0.7424430847167969",
+				"0.2024159431457519",
+				"1.089555740356445",
+				"93766.59830729169",
+				"93609.81640625",
+				"93719.5234375",
+				"94054.90625",
+				"0.0",
+				"0.0",
+				"99.1004"
+			],
+			[
+				"2021-01-03",
+				"111",
+				"98.9110741636266",
+				"18.8290518229066",
+				"16.220223",
+				"-2.167963743211233",
+				"-2.167963743211233",
+				"-2.167963743211233",
+				"-2.167963743211233",
+				"302.157816363544",
+				"125.87794661521912",
+				"428.5329580307007",
+				"297.9074567556381",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"284.361914952596",
+				"282.0005798339844",
+				"284.3917694091797",
+				"286.58689880371094",
+				"292.2354914347331",
+				"284.7713623046875",
+				"292.6560974121094",
+				"299.0417938232422",
+				"-0.2823683818181355",
+				"-0.746368408203125",
+				"-0.2679443359375",
+				"0.025634765625",
+				"-0.0188242594401041",
+				"-0.8005390167236328",
+				"-0.1092839241027832",
+				"1.4396820068359375",
+				"93706.63427734376",
+				"93498.85546875",
+				"93714.390625",
+				"93934.93359375",
+				"8.583068797918258e-07",
+				"3.576278665799274e-08",
+				"76.054115"
+			],
+			[
+				"2021-01-04",
+				"111",
+				"98.9110741636266",
+				"18.8290518229066",
+				"16.220223",
+				"-2.434690952302591",
+				"-2.434690952302591",
+				"-2.434690952302591",
+				"-2.434690952302591",
+				"284.1541578130024",
+				"124.73879754543304",
+				"435.0663423538208",
+				"273.4253853559494",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"284.37427775065106",
+				"282.8937072753906",
+				"284.25184631347656",
+				"286.4058380126953",
+				"292.2849267323812",
+				"285.5913848876953",
+				"292.7065124511719",
+				"299.1167907714844",
+				"-0.229190190633138",
+				"-0.7235107421875",
+				"-0.23980712890625",
+				"0.155670166015625",
+				"-0.0457668304443359",
+				"-0.7531013488769531",
+				"-0.0544595718383789",
+				"1.026752471923828",
+				"93747.88232421876",
+				"93593.5546875",
+				"93738.9375",
+				"93985.21875",
+				"8.52346317969932e-07",
+				"3.5514429915413835e-08",
+				"74.32602"
+			],
+			[
+				"2021-01-05",
+				"111",
+				"98.9110741636266",
+				"18.8290518229066",
+				"16.220223",
+				"-2.545657157899586",
+				"-2.545657157899586",
+				"-2.545657157899586",
+				"-2.545657157899586",
+				"244.8373702241153",
+				"138.09871673583984",
+				"320.1207518577576",
+				"247.5099042057991",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"285.6397705078125",
+				"283.18865966796875",
+				"285.47559356689453",
+				"287.8940887451172",
+				"292.99399820963544",
+				"285.23191833496094",
+				"293.4845123291016",
+				"300.2392883300781",
+				"-0.115427017211914",
+				"-0.3242645263671875",
+				"-0.1071090698242187",
+				"0.1171875",
+				"-0.1111276547114054",
+				"-0.89361572265625",
+				"-0.1935462951660156",
+				"0.8032312393188477",
+				"93674.06754557292",
+				"93527.921875",
+				"93654.044921875",
+				"93947.13671875",
+				"8.52346317969932e-07",
+				"3.5514429915413835e-08",
+				"32.67935"
+			],
+			[
+				"2021-01-06",
+				"111",
+				"98.9110741636266",
+				"18.8290518229066",
+				"16.220223",
+				"-2.233058929444795",
+				"-2.233058929444795",
+				"-2.233058929444795",
+				"-2.233058929444795",
+				"262.7748459941004",
+				"141.80883765220642",
+				"361.85210943222046",
+				"259.0714395046234",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"287.44138526916504",
+				"284.4318084716797",
+				"287.4009552001953",
+				"289.4769287109375",
+				"294.2729384104411",
+				"285.7767028808594",
+				"294.48319244384766",
+				"300.8690795898437",
+				"-0.2398378849029541",
+				"-0.60101318359375",
+				"-0.2313385009765625",
+				"0.003936767578125",
+				"0.1357771158218383",
+				"-0.6776275634765625",
+				"-0.1042418479919433",
+				"1.3055429458618164",
+				"93495.52425130208",
+				"93269.5625",
+				"93466.15625",
+				"93803.44921875",
+				"8.583068833445395e-07",
+				"3.576278680602248e-08",
+				"30.89605"
+			],
+			[
+				"2021-01-07",
+				"111",
+				"98.9110741636266",
+				"18.8290518229066",
+				"16.220223",
+				"-1.577744245530189",
+				"-1.577744245530189",
+				"-1.577744245530189",
+				"-1.577744245530189",
+				"297.2973425213884",
+				"218.97795796394348",
+				"459.12104845047",
+				"288.26625645160675",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"289.60484313964844",
+				"287.2174377441406",
+				"289.73238372802734",
+				"291.0367736816406",
+				"295.7462018330892",
+				"288.9295654296875",
+				"295.55543518066406",
+				"301.3641815185547",
+				"-0.2372339963912964",
+				"-0.5781517028808594",
+				"-0.2749457359313965",
+				"0.2410850524902343",
+				"0.3112451235453288",
+				"-0.3821392059326172",
+				"0.2287826538085937",
+				"1.0890655517578125",
+				"93405.30192057292",
+				"93201.05859375",
+				"93408.841796875",
+				"93695.72265625",
+				"1.570582389831543e-05",
+				"6.544093290964762e-07",
+				"37.29641"
+			],
+			[
+				"2021-01-08",
+				"111",
+				"98.9110741636266",
+				"18.8290518229066",
+				"16.220223",
+				"-1.9250904321682911",
+				"-1.9250904321682911",
+				"-1.9250904321682911",
+				"-1.9250904321682911",
+				"326.38799326448907",
+				"228.31469774246216",
+				"699.5754837989807",
+				"292.9360270500183",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"289.7435766855876",
+				"289.0696716308594",
+				"289.7289810180664",
+				"290.5402069091797",
+				"294.8905824025472",
+				"291.3871154785156",
+				"294.77689361572266",
+				"299.3087463378906",
+				"-0.7097173531850179",
+				"-0.990234375",
+				"-0.832435131072998",
+				"0.093658447265625",
+				"1.0163180033365886",
+				"-0.040740966796875",
+				"0.9340362548828124",
+				"2.2284393310546875",
+				"93527.37141927084",
+				"93317.01171875",
+				"93523.4765625",
+				"93751.015625",
+				"1.5759468073639482e-05",
+				"6.566445030683118e-07",
+				"40.975266"
+			],
+			[
+				"2021-01-09",
+				"111",
+				"98.9110741636266",
+				"18.8290518229066",
+				"16.220223",
+				"-0.4642456769946222",
+				"-0.4642456769946222",
+				"-0.4642456769946222",
+				"-0.4642456769946222",
+				"286.2489788634021",
+				"180.51928281784055",
+				"629.1856169700623",
+				"270.6805318593979",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"8453.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"5108.0",
+				"287.5004291534424",
+				"286.0792999267578",
+				"287.58426666259766",
+				"289.85243225097656",
+				"293.96658261617023",
+				"289.46221923828125",
+				"294.00975036621094",
+				"298.1237030029297",
+				"-0.656810998916626",
+				"-0.943603515625",
+				"-0.6699686050415039",
+				"-0.1032257080078125",
+				"1.315358320871989",
+				"0.4655609130859375",
+				"1.3779144287109375",
+				"2.1102447509765625",
+				"93559.13590494792",
+				"93332.21484375",
+				"93562.962890625",
+				"93807.5234375",
+				"3.073054699598288e-06",
+				"1.280439458165953e-07",
+				"34.487396"
+			]
+		],
+		"detail-image-url": "assets/regions/thailand.png"
+	},
+	{
+		"name": "Cross Country Poverty Mapping Model for Indonesia, Timor Leste and Myanmar",
+		"description": "This is a single cross-country sklearn Random Forest regressor model for predicting relative wealth for Indonesia, Timor Leste and Myanmar. Through a post-training binning process, the model also predicts a quintile-grouped relative wealth category ('A' to 'E')  It is a single-country model trained on open datasets from Earth Observation Group (EOG) nightlights data, Open Streetmap (OSM) Points of Interest (POI) data, Ookla internet speed data as well as Domestic and Health Survey (DHS) data from USAID.  It was built as part of the UNICEF AI4D Poverty Mapping Project which aims to develop open datasets and machine learning (ML) models for poverty mapping estimation across nine countries  in Southeast Asia (SEA).\n",
+		"card-type": "model",
+		"organization": {
+			"name": "Unicef East Asia and Pacific Regional Office",
+			"url": "https://www.unicef.org/eap/"
+		},
+		"date-added": "2022-03-02",
+		"tags": [
+			"poverty-mapping",
+			"timor-leste",
+			"sklearn-model",
+			"machine-learning"
+		],
+		"country-region": ["indonesia", "myanmar", "timor-leste"],
+		"year-period": 2016,
+		"evaluation-metrics": [
+			{
+				"metric": {
+					"metric-type": "rsquared",
+					"value": 0.6
+				},
+				"link": {
+					"description": "Model evaluation using cross-validation",
+					"url": "https://thinkingmachines.github.io/unicef-ai4d-poverty-mapping/notebooks/2023-01-17-initial-model-ph-mm-tl-kh/model_tl.html#evaluate-model-training-using-cross-validation"
+				}
+			},
+			{
+				"link": {
+					"description": "SHAP Feature Importance Plots",
+					"url": "https://thinkingmachines.github.io/unicef-ai4d-poverty-mapping/notebooks/2023-01-17-initial-model-ph-mm-tl-kh/model_tl.html#shap-feature-importance"
+				}
+			}
+		],
+		"links": [
+			{
+				"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping",
+				"description": "UNICEF AI4D Poverty Mapping Project Github Repository",
+				"type": "repository"
+			},
+			{
+				"url": "https://drive.google.com/file/d/1q9ev9qlXf5p0-CTuJ8IO6Qi-tEIuRqCp/view?usp=share_link",
+				"description": "Timor Leste Poverty Mapping Model Weights (.pkl). See related notebooks for usage",
+				"type": "model-weights"
+			},
+			{
+				"url": "https://www.googleapis.com/drive/v3/files/14nejv32UOBJK6fUzOJamMvn172vZN_WB?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+				"description": "Country wide rollout (inference) of the Poverty Mapping Model on Timor Leste using 2.4km grids (bingtile quadkey level 14) as CSV",
+				"type": "dataset-raw-csv",
+				"name": "2023-02-21-tl-rollout-output.csv",
+				"alt-format": [
+					{
+						"url": "https://www.googleapis.com/drive/v3/files/14nejv32UOBJK6fUzOJamMvn172vZN_WB?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+						"type": "dataset-raw-csv"
+					}
+				]
+			},
+			{
+				"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/tl/1_tl_train_model.ipynb",
+				"description": "Timor Leste Model Rollout Part 1 (Train Single-country Model)",
+				"type": "code-notebook"
+			},
+			{
+				"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/tl/2_tl_generate_grids.ipynb",
+				"description": "Timor Leste Model Rollout Part 2 (Generate Roll-out Grids)",
+				"type": "code-notebook"
+			},
+			{
+				"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/tl/3_tl_rollout_model.ipynb",
+				"description": "Timor Leste Model Rollout Part 3 (Feature Engineering and Model Prediction on Rollout Grids)",
+				"type": "code-notebook"
+			},
+			{
+				"url": "https://www.googleapis.com/drive/v3/files/15xrSAyWkFZRwVuGtECTRwNz06amRsjew?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+				"description": "Training dataset for Poverty Mapping Model on Timor Leste as CSV",
+				"type": "training-dataset-csv",
+				"name": "2023-02-21-tl-dhs-cluster-features-all.csv",
+				"alt-format": [
+					{
+						"url": "https://www.googleapis.com/drive/v3/files/15xrSAyWkFZRwVuGtECTRwNz06amRsjew?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+						"type": "training-dataset-csv"
+					}
+				]
+			}
+		],
+		"id": "povmap-cross-country-model",
+		"data-columns": [
+			{
+				"name": "quadkey",
+				"type": "integer",
+				"hxltag": "#geo+code+v_quadkeys"
+			},
+			{
+				"name": "shapeName",
+				"type": "string",
+				"hxltag": "#adm2+name"
+			},
+			{
+				"name": "shapeISO",
+				"type": "float64"
+			},
+			{
+				"name": "shapeID",
+				"type": "string",
+				"hxltag": "#adm2+code+v_pcodes"
+			},
+			{
+				"name": "shapeGroup",
+				"type": "string",
+				"hxltag": "#adm0+code+v_pcodes"
+			},
+			{
+				"name": "shapeType",
+				"type": "string"
+			},
+			{
+				"name": "pop_count",
+				"type": "float64",
+				"hxltag": "#population"
+			},
+			{
+				"name": "Predicted Relative Wealth Index",
+				"type": "float64"
+			},
+			{
+				"name": "Predicted Wealth Category (quintile)",
+				"type": "string"
+			},
+			{
+				"name": "poi_count",
+				"type": "float64"
+			},
+			{
+				"name": "atm_count",
+				"type": "float64"
+			},
+			{
+				"name": "atm_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "bank_count",
+				"type": "float64"
+			},
+			{
+				"name": "bank_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "bus_station_count",
+				"type": "float64"
+			},
+			{
+				"name": "bus_station_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "cafe_count",
+				"type": "float64"
+			},
+			{
+				"name": "cafe_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "charging_station_count",
+				"type": "float64"
+			},
+			{
+				"name": "charging_station_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "courthouse_count",
+				"type": "float64"
+			},
+			{
+				"name": "courthouse_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "dentist_count",
+				"type": "float64"
+			},
+			{
+				"name": "dentist_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "fast_food_count",
+				"type": "float64"
+			},
+			{
+				"name": "fast_food_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "fire_station_count",
+				"type": "float64"
+			},
+			{
+				"name": "fire_station_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "food_court_count",
+				"type": "float64"
+			},
+			{
+				"name": "food_court_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "fuel_count",
+				"type": "float64"
+			},
+			{
+				"name": "fuel_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "hospital_count",
+				"type": "float64"
+			},
+			{
+				"name": "hospital_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "library_count",
+				"type": "float64"
+			},
+			{
+				"name": "library_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "marketplace_count",
+				"type": "float64"
+			},
+			{
+				"name": "marketplace_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "pharmacy_count",
+				"type": "float64"
+			},
+			{
+				"name": "pharmacy_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "police_count",
+				"type": "float64"
+			},
+			{
+				"name": "police_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "post_box_count",
+				"type": "float64"
+			},
+			{
+				"name": "post_box_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "post_office_count",
+				"type": "float64"
+			},
+			{
+				"name": "post_office_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "restaurant_count",
+				"type": "float64"
+			},
+			{
+				"name": "restaurant_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "social_facility_count",
+				"type": "float64"
+			},
+			{
+				"name": "social_facility_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "supermarket_count",
+				"type": "float64"
+			},
+			{
+				"name": "supermarket_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "townhall_count",
+				"type": "float64"
+			},
+			{
+				"name": "townhall_nearest",
+				"type": "float64"
+			},
+			{
+				"name": "road_count",
+				"type": "float64"
+			},
+			{
+				"name": "fixed_2019_mean_avg_d_kbps_mean",
+				"type": "float64"
+			},
+			{
+				"name": "fixed_2019_mean_avg_u_kbps_mean",
+				"type": "float64"
+			},
+			{
+				"name": "fixed_2019_mean_avg_lat_ms_mean",
+				"type": "float64"
+			},
+			{
+				"name": "fixed_2019_mean_num_tests_mean",
+				"type": "float64"
+			},
+			{
+				"name": "fixed_2019_mean_num_devices_mean",
+				"type": "float64"
+			},
+			{
+				"name": "mobile_2019_mean_avg_d_kbps_mean",
+				"type": "float64"
+			},
+			{
+				"name": "mobile_2019_mean_avg_u_kbps_mean",
+				"type": "float64"
+			},
+			{
+				"name": "mobile_2019_mean_avg_lat_ms_mean",
+				"type": "float64"
+			},
+			{
+				"name": "mobile_2019_mean_num_tests_mean",
+				"type": "float64"
+			},
+			{
+				"name": "mobile_2019_mean_num_devices_mean",
+				"type": "float64"
+			},
+			{
+				"name": "avg_rad_min",
+				"type": "float64"
+			},
+			{
+				"name": "avg_rad_max",
+				"type": "float64"
+			},
+			{
+				"name": "avg_rad_mean",
+				"type": "float64"
+			},
+			{
+				"name": "avg_rad_std",
+				"type": "float64"
+			},
+			{
+				"name": "avg_rad_median",
+				"type": "float64"
+			},
+			{
+				"name": "geometry",
+				"type": "string",
+				"hxltag": "#geo+bounds"
+			}
+		],
+		"sample-data": [
+			[
+				"#geo+code+v_quadkeys",
+				"#adm2+name",
+				"",
+				"#adm2+code+v_pcodes",
+				"#adm0+code+v_pcodes",
+				"",
+				"#population",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"#geo+bounds"
+			],
+			[
+				"31011220203121",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				"102.251936",
+				"0.23240344360439735",
+				"D",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"1.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.05740397050976753",
+				"-0.013148820959031582",
+				"-0.033543553352355954",
+				"0.010571325122594713",
+				"-0.03205060213804245",
+				"POLYGON ((124.03564453124997 -9.340672181980946, 124.03564453124997 -9.318990192397923, 124.05761718750001 -9.318990192397923, 124.05761718750001 -9.340672181980946, 124.03564453124997 -9.340672181980946))"
+			],
+			[
+				"31011220203123",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				"992.492772",
+				"0.2111057463465348",
+				"E",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"14.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.015356705524027348",
+				"0.08718188852071762",
+				"0.014896172285079955",
+				"0.029146260698214407",
+				"0.00800419133156538",
+				"POLYGON ((124.03564453124997 -9.362352822055612, 124.03564453124997 -9.340672181980946, 124.05761718750001 -9.340672181980946, 124.05761718750001 -9.362352822055612, 124.03564453124997 -9.362352822055612))"
+			],
+			[
+				"31011220203130",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				"118.8976",
+				"0.2515657443952317",
+				"C",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"1.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.051340773701667786",
+				"0.008125613443553448",
+				"-0.020882872740427653",
+				"0.015269606968572111",
+				"-0.021259546279907227",
+				"POLYGON ((124.05761718750001 -9.340672181980946, 124.05761718750001 -9.318990192397923, 124.07958984375001 -9.318990192397923, 124.07958984375001 -9.340672181980946, 124.05761718750001 -9.340672181980946))"
+			],
+			[
+				"31011220203132",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				"513.637632",
+				"0.22745668363922827",
+				"D",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"19.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.027551764622330666",
+				"0.11148908734321594",
+				"0.009794714053471883",
+				"0.0310843790886148",
+				"0.0025376772973686457",
+				"POLYGON ((124.05761718750001 -9.362352822055612, 124.05761718750001 -9.340672181980946, 124.07958984375001 -9.340672181980946, 124.07958984375001 -9.362352822055612, 124.05761718750001 -9.362352822055612))"
+			],
+			[
+				"31011220203310",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				"319.14094",
+				"0.2530400714862823",
+				"C",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"3.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.013157193548977375",
+				"0.110741026699543",
+				"0.009971243143081666",
+				"0.028430479286307597",
+				"0.00040320446714758873",
+				"POLYGON ((124.05761718750001 -9.384032109601685, 124.05761718750001 -9.362352822055612, 124.07958984375001 -9.362352822055612, 124.07958984375001 -9.384032109601685, 124.05761718750001 -9.384032109601685))"
+			],
+			[
+				"31011220203312",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				"41.089748",
+				"0.18248490134698422",
+				"E",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"3.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.006636444479227066",
+				"0.6482799649238586",
+				"0.14392496744791666",
+				"0.1506665630092592",
+				"0.08776599168777466",
+				"POLYGON ((124.05761718750001 -9.405710041600031, 124.05761718750001 -9.384032109601685, 124.07958984375001 -9.384032109601685, 124.07958984375001 -9.405710041600031, 124.05761718750001 -9.405710041600031))"
+			],
+			[
+				"31011220203131",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				"584.976192",
+				"0.20513808546199963",
+				"E",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"19.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.04205385223031044",
+				"0.17275787889957428",
+				"0.027438087463378905",
+				"0.053644539121898815",
+				"0.01014959067106247",
+				"POLYGON ((124.07958984375001 -9.340672181980946, 124.07958984375001 -9.318990192397923, 124.1015625 -9.318990192397923, 124.1015625 -9.340672181980946, 124.07958984375001 -9.340672181980946))"
+			],
+			[
+				"31011220203133",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				"242.551104",
+				"0.2213118179533992",
+				"D",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"13.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.008026275783777237",
+				"0.09710018336772919",
+				"0.02960465431213379",
+				"0.031130596719522945",
+				"0.016106536611914635",
+				"POLYGON ((124.07958984375001 -9.362352822055612, 124.07958984375001 -9.340672181980946, 124.1015625 -9.340672181980946, 124.1015625 -9.362352822055612, 124.07958984375001 -9.362352822055612))"
+			],
+			[
+				"31011220203311",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				"9.511808",
+				"0.1742399483752813",
+				"E",
+				"0.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"0.0",
+				"10000.0",
+				"6.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"0.0",
+				"-0.03246933966875076",
+				"0.040090519934892654",
+				"-0.0012122179567813874",
+				"0.016693634912798502",
+				"0.0029176787938922644",
+				"POLYGON ((124.07958984375001 -9.384032109601685, 124.07958984375001 -9.362352822055612, 124.1015625 -9.362352822055612, 124.1015625 -9.384032109601685, 124.07958984375001 -9.384032109601685))"
+			]
+		],
+		"detail-image-url": "assets/multiregions/indonesia-myanmar-timor-leste.png"
+	},
+	{
+		"name": "Poverty Mapping Rollout Dataset for Timor Leste",
+		"description": "This is the rollout dataset of relative wealth predictions relative wealth for Timor Leste.  (add more details here later...)",
+		"card-type": "dataset",
+		"organization": {
+			"name": "Thinking Machines Data Sciences Inc",
+			"url": "https://thinkingmachin.es"
+		},
+		"date-added": "2023-03-02",
+		"tags": ["poverty-mapping", "timor-leste"],
+		"country-region": ["timor-leste"],
+		"year-period": 2016,
+		"links": [
+			{
+				"url": "https://raw.githubusercontent.com/butchtm/unicef-ai4d-poverty-mapping/feat/convert-geojsons-to-csvs/notebooks/2023-02-21-single-country-rollouts/rollout_output_tl.geojson",
+				"description": "Country wide rollout (inference) of the Poverty Mapping Model on Timor Leste using 2.4km grids (bingtile quadkey level 14) as geojson",
+				"type": "dataset-raw-geojson",
+				"alt-format": [
+					{
+						"url": "https://raw.githubusercontent.com/butchtm/unicef-ai4d-poverty-mapping/feat/convert-geojsons-to-csvs/notebooks/2023-02-21-single-country-rollouts/rollout_output_tl.geojson",
+						"type": "dataset-raw-geojson"
+					},
+					{
+						"url": "https://raw.githubusercontent.com/butchtm/unicef-ai4d-poverty-mapping/feat/convert-geojsons-to-csvs/notebooks/2023-02-21-single-country-rollouts/rollout_output_tl.csv",
+						"type": "dataset-raw-csv"
+					}
+				],
+				"name": "rollout_output_tl.geojson"
+			},
+			{
+				"url": "https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/feat/convert-geojsons-to-csvs/notebooks/2023-02-21-single-country-rollouts/2023-03-02-tl_final_model_rollout.ipynb",
+				"description": "Timor Leste Model Rollout Part 3 (Feature Engineering and Model Prediction on Rollout Grids)",
+				"type": "code-notebook"
+			},
+			{
+				"url": "https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/feat/convert-geojsons-to-csvs/notebooks/2023-02-21-single-country-rollouts/2023_02-21-tl_final_model_training.ipynb",
+				"description": "Timor Leste Model Rollout Part 1 (Training Final Single-country Model)",
+				"type": "code-notebook"
+			},
+			{
+				"url": "https://github.com/butchtm/unicef-ai4d-poverty-mapping/blob/feat/convert-geojsons-to-csvs/notebooks/2023-02-21-single-country-rollouts/2023-03-01-tl_generate_populated_grids.ipynb",
+				"description": "Timor Leste Model Rollout Part 2 (Generate Roll-out Grids)",
+				"type": "code-notebook"
+			}
+		],
+		"data-columns": [
+			{
+				"name": "quadkey",
+				"type": "string"
+			},
+			{
+				"name": "shapeName",
+				"type": "string"
+			},
+			{
+				"name": "shapeISO",
+				"type": "string"
+			},
+			{
+				"name": "shapeID",
+				"type": "string"
+			},
+			{
+				"name": "shapeGroup",
+				"type": "string"
+			},
+			{
+				"name": "shapeType",
+				"type": "string"
+			},
+			{
+				"name": "pop_count",
+				"type": "float"
+			},
+			{
+				"name": "Predicted Relative Wealth Index",
+				"type": "float"
+			},
+			{
+				"name": "Predicted Wealth Category (quintile)",
+				"type": "string"
+			},
+			{
+				"name": "Predicted Wealth Category (split-quintile)",
+				"type": "string"
+			},
+			{
+				"name": "geometry",
+				"type": "string"
+			}
+		],
+		"sample-data": [
+			[
+				31011220203121,
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				102.251936,
+				-0.32614251865998456,
+				"E",
+				"E",
+				"POLYGON ((124.03564453125 -9.340672181980946, 124.03564453125 -9.318990192397923, 124.0576171875 -9.318990192397923, 124.0576171875 -9.340672181980946, 124.03564453125 -9.340672181980946))"
+			],
+			[
+				31011220203123,
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				992.492772,
+				0.1447559201393492,
+				"C",
+				"C",
+				"POLYGON ((124.03564453125 -9.362352822055612, 124.03564453125 -9.340672181980946, 124.0576171875 -9.340672181980946, 124.0576171875 -9.362352822055612, 124.03564453125 -9.362352822055612))"
+			],
+			[
+				31011220203130,
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				118.8976,
+				-0.31718538830078946,
+				"E",
+				"E",
+				"POLYGON ((124.0576171875 -9.340672181980946, 124.0576171875 -9.318990192397923, 124.07958984375 -9.318990192397923, 124.07958984375 -9.340672181980946, 124.0576171875 -9.340672181980946))"
+			],
+			[
+				31011220203132,
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				513.637632,
+				0.07455815999209406,
+				"C",
+				"C",
+				"POLYGON ((124.0576171875 -9.362352822055612, 124.0576171875 -9.340672181980946, 124.07958984375 -9.340672181980946, 124.07958984375 -9.362352822055612, 124.0576171875 -9.362352822055612))"
+			],
+			[
+				31011220203310,
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				319.14094,
+				-0.0210791963118972,
+				"C",
+				"C",
+				"POLYGON ((124.0576171875 -9.384032109601685, 124.0576171875 -9.362352822055612, 124.07958984375 -9.362352822055612, 124.07958984375 -9.384032109601685, 124.0576171875 -9.384032109601685))"
+			],
+			[
+				31011220203312,
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				41.089748,
+				0.7565705461937821,
+				"A",
+				"A",
+				"POLYGON ((124.0576171875 -9.405710041600031, 124.0576171875 -9.384032109601685, 124.07958984375 -9.384032109601685, 124.07958984375 -9.405710041600031, 124.0576171875 -9.405710041600031))"
+			]
+		],
+		"id": "povmap-timor-leste-rollout-dataset",
+		"detail-image-url": "assets/items/povmap-timor-leste-rollout-dataset.png"
+	},
+	{
+		"name": "Poverty Mapping Model for Timor Leste",
+		"description": "This is an sklearn Random Forest regressor model for predicting relative wealth for Timor Leste. Through a post-training binning process, the model also predicts a quintile-grouped relative wealth category ('A' to 'E')  It is a single-country model trained on open datasets from Earth Observation Group (EOG) nightlights data, Open Streetmap (OSM) Points of Interest (POI) data, Ookla internet speed data as well as Domestic and Health Survey (DHS) data from USAID.  It was built as part of the UNICEF AI4D Poverty Mapping Project which aims to develop open datasets and machine learning (ML) models for poverty mapping estimation across nine countries  in Southeast Asia (SEA).\n",
+		"card-type": "model",
+		"organization": {
+			"name": "Unicef East Asia and Pacific Regional Office",
+			"url": "https://www.unicef.org/eap/"
+		},
+		"date-added": "2022-03-02",
+		"tags": [
+			"poverty-mapping",
+			"timor-leste",
+			"sklearn-model",
+			"machine-learning"
+		],
+		"country-region": ["timor-leste"],
+		"year-period": 2016,
+		"evaluation-metrics": [
+			{
+				"metric": {
+					"metric-type": "rsquared",
+					"value": 0.6
+				},
+				"link": {
+					"description": "Model evaluation using cross-validation",
+					"url": "https://thinkingmachines.github.io/unicef-ai4d-poverty-mapping/notebooks/2023-01-17-initial-model-ph-mm-tl-kh/model_tl.html#evaluate-model-training-using-cross-validation"
+				}
+			},
+			{
+				"link": {
+					"description": "SHAP Feature Importance Plots",
+					"url": "https://thinkingmachines.github.io/unicef-ai4d-poverty-mapping/notebooks/2023-01-17-initial-model-ph-mm-tl-kh/model_tl.html#shap-feature-importance"
+				}
+			}
+		],
+		"links": [
+			{
+				"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping",
+				"description": "UNICEF AI4D Poverty Mapping Project Github Repository",
+				"type": "repository"
+			},
+			{
+				"url": "https://drive.google.com/file/d/1q9ev9qlXf5p0-CTuJ8IO6Qi-tEIuRqCp/view?usp=share_link",
+				"description": "Timor Leste Poverty Mapping Model Weights (.pkl). See related notebooks for usage",
+				"type": "model-weights"
+			},
+			{
+				"url": "https://www.googleapis.com/drive/v3/files/1zTE3X6vQlJEKPpnLzrBd7OA84rwIsO1e?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+				"description": "Country wide rollout (inference) of the Poverty Mapping Model on Timor Leste using 2.4km grids (bingtile quadkey level 14)",
+				"type": "dataset-raw-geojson",
+				"name": "2023-02-21-tl-rollout-output.geojson",
+				"alt-format": [
+					{
+						"url": "https://www.googleapis.com/drive/v3/files/1zTE3X6vQlJEKPpnLzrBd7OA84rwIsO1e?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+						"type": "dataset-raw-geojson"
+					},
+					{
+						"url": "https://www.googleapis.com/drive/v3/files/14nejv32UOBJK6fUzOJamMvn172vZN_WB?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+						"type": "dataset-raw-csv"
+					}
+				]
+			},
+			{
+				"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/tl/1_tl_train_model.ipynb",
+				"description": "Timor Leste Model Rollout Part 1 (Train Single-country Model)",
+				"type": "code-notebook"
+			},
+			{
+				"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/tl/2_tl_generate_grids.ipynb",
+				"description": "Timor Leste Model Rollout Part 2 (Generate Roll-out Grids)",
+				"type": "code-notebook"
+			},
+			{
+				"url": "https://github.com/thinkingmachines/unicef-ai4d-poverty-mapping/blob/main/notebooks/2023-02-21-single-country-rollouts/tl/3_tl_rollout_model.ipynb",
+				"description": "Timor Leste Model Rollout Part 3 (Feature Engineering and Model Prediction on Rollout Grids)",
+				"type": "code-notebook"
+			},
+			{
+				"url": "https://www.googleapis.com/drive/v3/files/15xrSAyWkFZRwVuGtECTRwNz06amRsjew?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+				"description": "Training dataset for Poverty Mapping Model on Timor Leste as CSV",
+				"type": "training-dataset-csv",
+				"name": "2023-02-21-tl-dhs-cluster-features-all.csv",
+				"alt-format": [
+					{
+						"url": "https://www.googleapis.com/drive/v3/files/15xrSAyWkFZRwVuGtECTRwNz06amRsjew?alt=media&key=AIzaSyB5JriqHaz9gwrdN7Ly15h4lkNkC9xC8a4",
+						"type": "training-dataset-csv"
+					}
+				]
+			}
+		],
+		"id": "povmap-timor-leste",
+		"data-columns": [
+			{
+				"name": "quadkey",
+				"type": "string"
+			},
+			{
+				"name": "shapeName",
+				"type": "string"
+			},
+			{
+				"name": "shapeISO",
+				"type": "string"
+			},
+			{
+				"name": "shapeID",
+				"type": "string"
+			},
+			{
+				"name": "shapeGroup",
+				"type": "string"
+			},
+			{
+				"name": "shapeType",
+				"type": "string"
+			},
+			{
+				"name": "pop_count",
+				"type": "string"
+			},
+			{
+				"name": "Predicted Relative Wealth Index",
+				"type": "string"
+			},
+			{
+				"name": "Predicted Wealth Category (quintile)",
+				"type": "string"
+			},
+			{
+				"name": "geometry",
+				"type": "string"
+			}
+		],
+		"sample-data": [
+			[
+				"31011220203121",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				102.251936,
+				0.21988249666436613,
+				"D",
+				"{\"type\": \"Polygon\", \"coordinates\": [[[124.03564453124997, -9.340672181980946], [124.03564453124997, -9.318990192397923], [124.05761718750001, -9.318990192397923], [124.05761718750001, -9.340672181980946], [124.03564453124997, -9.340672181980946]]]}"
+			],
+			[
+				"31011220203123",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				992.492772,
+				0.20989184350645537,
+				"E",
+				"{\"type\": \"Polygon\", \"coordinates\": [[[124.03564453124997, -9.362352822055612], [124.03564453124997, -9.340672181980946], [124.05761718750001, -9.340672181980946], [124.05761718750001, -9.362352822055612], [124.03564453124997, -9.362352822055612]]]}"
+			],
+			[
+				"31011220203130",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				118.8976,
+				0.24715248872643436,
+				"C",
+				"{\"type\": \"Polygon\", \"coordinates\": [[[124.05761718750001, -9.340672181980946], [124.05761718750001, -9.318990192397923], [124.07958984375001, -9.318990192397923], [124.07958984375001, -9.340672181980946], [124.05761718750001, -9.340672181980946]]]}"
+			],
+			[
+				"31011220203132",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				513.637632,
+				0.20913763852195852,
+				"E",
+				"{\"type\": \"Polygon\", \"coordinates\": [[[124.05761718750001, -9.362352822055612], [124.05761718750001, -9.340672181980946], [124.07958984375001, -9.340672181980946], [124.07958984375001, -9.362352822055612], [124.05761718750001, -9.362352822055612]]]}"
+			],
+			[
+				"31011220203310",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				319.14094,
+				0.2422579441371858,
+				"D",
+				"{\"type\": \"Polygon\", \"coordinates\": [[[124.05761718750001, -9.384032109601685], [124.05761718750001, -9.362352822055612], [124.07958984375001, -9.362352822055612], [124.07958984375001, -9.384032109601685], [124.05761718750001, -9.384032109601685]]]}"
+			],
+			[
+				"31011220203312",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				41.089748,
+				0.2071596669233114,
+				"E",
+				"{\"type\": \"Polygon\", \"coordinates\": [[[124.05761718750001, -9.405710041600031], [124.05761718750001, -9.384032109601685], [124.07958984375001, -9.384032109601685], [124.07958984375001, -9.405710041600031], [124.05761718750001, -9.405710041600031]]]}"
+			],
+			[
+				"31011220203131",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				584.976192,
+				0.21092795025458158,
+				"E",
+				"{\"type\": \"Polygon\", \"coordinates\": [[[124.07958984375001, -9.340672181980946], [124.07958984375001, -9.318990192397923], [124.1015625, -9.318990192397923], [124.1015625, -9.340672181980946], [124.07958984375001, -9.340672181980946]]]}"
+			],
+			[
+				"31011220203133",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				242.551104,
+				0.2029523831707937,
+				"E",
+				"{\"type\": \"Polygon\", \"coordinates\": [[[124.07958984375001, -9.362352822055612], [124.07958984375001, -9.340672181980946], [124.1015625, -9.340672181980946], [124.1015625, -9.362352822055612], [124.07958984375001, -9.362352822055612]]]}"
+			],
+			[
+				"31011220203311",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				9.511808,
+				0.17983406739013355,
+				"E",
+				"{\"type\": \"Polygon\", \"coordinates\": [[[124.07958984375001, -9.384032109601685], [124.07958984375001, -9.362352822055612], [124.1015625, -9.362352822055612], [124.1015625, -9.384032109601685], [124.07958984375001, -9.384032109601685]]]}"
+			],
+			[
+				"31011220203313",
+				"Nitibe",
+				"None",
+				"TLS-ADM2-3_0_0-B58",
+				"TLS",
+				"ADM2",
+				16.495832,
+				0.2009947802592618,
+				"E",
+				"{\"type\": \"Polygon\", \"coordinates\": [[[124.07958984375001, -9.405710041600031], [124.07958984375001, -9.384032109601685], [124.1015625, -9.384032109601685], [124.1015625, -9.405710041600031], [124.07958984375001, -9.405710041600031]]]}"
+			]
+		],
+		"detail-image-url": "assets/items/povmap-timor-leste.png"
+	}
+]

--- a/public/api/data/fixtures/featured.json
+++ b/public/api/data/fixtures/featured.json
@@ -1,0 +1,5 @@
+[
+	{ "id": "airquality-thailand-model" },
+	{ "id": "povmap-philippines" },
+	{ "id": "povmap-cross-country-model" }
+]

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,9 +2,21 @@
 import type { CatalogueItemType } from 'types/CatalogueItem.type'
 import HOME_PATH from '../constants'
 
+let CATALOG_PATH = ''
+
+if (process.env.NODE_ENV === 'test') {
+	console.log('LOG: Using testing environment... Loading from fixtures')
+	CATALOG_PATH = '/api/data/fixtures/'
+} else if (
+	process.env.NODE_ENV === 'production' ||
+	process.env.NODE_ENV === 'development'
+) {
+	CATALOG_PATH = '/api/data/'
+}
+
 export const fetchCatalogItems = async (): Promise<CatalogueItemType[]> => {
 	try {
-		const response = await fetch(`${HOME_PATH}/api/data/catalog.json`)
+		const response = await fetch(`${HOME_PATH}${CATALOG_PATH}catalog.json`)
 		const catalog: CatalogueItemType[] =
 			(await response.json()) as CatalogueItemType[]
 		return catalog
@@ -16,7 +28,7 @@ export const fetchCatalogItems = async (): Promise<CatalogueItemType[]> => {
 
 export const fetchFeaturedIds = async (): Promise<Record<string, string>[]> => {
 	try {
-		const response = await fetch(`${HOME_PATH}/api/data/featured.json`)
+		const response = await fetch(`${HOME_PATH}${CATALOG_PATH}featured.json`)
 		const featured: Record<string, string>[] =
 			(await response.json()) as Record<string, string>[]
 		return featured


### PR DESCRIPTION
## Extra details

Updates automated testing and tests to use a fixtures file instead of live `catalog.json` files. This should make writing tests easier and more consistent.

Future suggestions: Once more versions of the fixtures file gets uploaded, you will want the create a subfolder in the fixtures directory to track the version history of old fixtures files

## Changelog

Add a summary of the things that were changed

- [x] add pnpm script for building a test env
- [x] remove creation of `catalog.json` from `test.yaml`
- [x] update `test.yaml` to build test env
- [x] add  fixture files
- [x] update `fetchCatalogItems` and  `fetchFeaturedIds` to conditionally get path based on NODE_ENV`
- [x] update tests to only consider `catalog.json` from `api/data/fixtures` directory

## How to test

- n/a