### PR TITLE
fix: update mobile responsiveness, contribution page updates

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import HOME_PATH from '../constants'
 
 const Footer = () => (
 	<div
-		className='flex h-12 justify-center bg-[#F9FAFB] p-3 px-10 text-[#82838D]'
+		className='flex justify-center bg-[#F9FAFB] p-2 px-10 text-xs text-[#82838D] sm:h-12 sm:p-3 sm:text-base'
 		data-cy='footer'
 	>
 		<div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,16 +2,16 @@ import { Link } from 'react-router-dom'
 import HOME_PATH from '../constants'
 
 const Header = () => (
-	<div className='flex h-12 bg-white p-3 px-10 text-cloud-burst'>
+	<div className='flex h-12 bg-white p-4 px-5 text-cloud-burst sm:p-3 sm:px-10'>
 		<Link
 			to={`${HOME_PATH}/`}
-			className='font-semibold hover:text-gray-600 hover:duration-500'
+			className='text-sm font-semibold hover:text-gray-600 hover:duration-500 sm:text-base'
 		>
 			AI4D Research Bank
 		</Link>
 		<Link
 			to={`${HOME_PATH}/catalogue`}
-			className='ml-5 font-medium text-gray-500 hover:text-cloud-burst hover:duration-500'
+			className='ml-5 text-sm font-medium text-gray-500 hover:text-cloud-burst hover:duration-500 sm:text-base'
 		>
 			Catalogue
 		</Link>

--- a/src/pages/CatalogueItemPage.tsx
+++ b/src/pages/CatalogueItemPage.tsx
@@ -135,14 +135,13 @@ const CatalogueItemPage = () => {
 					/>
 				) : null}
 				<div className='absolute z-10 h-full w-full bg-cloud-burst opacity-80 brightness-75' />
-
-				<span className='z-20 self-start pl-28 text-3xl font-medium tracking-tighter'>
+				<span className='z-20 self-start text-xl font-medium tracking-tighter sm:pl-28 sm:text-3xl'>
 					{name} {yearPeriodTitle}
 				</span>
-				<div className='z-20 mt-2 flex flex-row gap-3 self-start pl-28 text-sm'>
+				<div className='z-20 mt-2 flex w-full flex-row gap-3 self-start text-xs sm:pl-28 sm:text-sm'>
 					<a
 						href={organization.url}
-						className='z-20 self-start text-sm hover:underline'
+						className='w-50 z-20 self-start text-xs hover:underline  sm:w-auto sm:text-sm'
 						target='_blank'
 						rel='noreferrer'
 					>
@@ -153,7 +152,7 @@ const CatalogueItemPage = () => {
 				</div>
 			</div>
 
-			<div className='flex flex-col pl-28 md:flex-row'>
+			<div className='flex flex-col sm:pl-28 md:flex-row'>
 				<div className='flex w-full flex-col gap-4 p-10 text-cloud-burst md:w-2/3'>
 					<Tabs defaultActiveKey='1' items={tabItems} />
 				</div>

--- a/src/pages/CataloguePage.tsx
+++ b/src/pages/CataloguePage.tsx
@@ -163,7 +163,7 @@ const CataloguePage = () => {
 	}
 
 	return (
-		<div className='min-h-[calc(100vh_-_3rem)] bg-white'>
+		<div className='min-h-[calc(100vh_-_3rem)] w-full bg-white'>
 			<div className='relative flex flex-col items-center justify-center py-10 px-10 '>
 				<img
 					src={CatalogueHeroImg}
@@ -180,7 +180,7 @@ const CataloguePage = () => {
 					<SearchInput onSearchBtnClick={onSearchBtnClick} path='' />
 				</div>
 
-				<div className='flex'>
+				<div className='flex w-full flex-col md:flex-row'>
 					<div className='mr-16 w-full self-start rounded-md bg-gray-50 p-6 md:w-1/3'>
 						<span className='font-semibold text-cloud-burst'>FILTERS</span>
 						<Space style={{ width: '100%' }} direction='vertical'>
@@ -241,14 +241,16 @@ const CataloguePage = () => {
 							</div>
 						</Space>
 					</div>
-					<div className='my-5 flex w-full flex-col md:my-0 md:w-2/3'>
-						<div className='flex'>
-							<CustomRadio
-								updateParentOptions={(value: ToggleOption) => {
-									setRadioOptions(value)
-								}}
-							/>
-							<div className='mx-6 py-1 text-sm font-normal text-[#82838D]'>
+					<div className='my-5 w-full flex-col md:my-0 md:w-2/3'>
+						<div className='flex flex-col md:flex-row'>
+							<div className='mb-5 md:mb-auto'>
+								<CustomRadio
+									updateParentOptions={(value: ToggleOption) => {
+										setRadioOptions(value)
+									}}
+								/>
+							</div>
+							<div className='py-1 text-sm font-normal text-[#82838D] md:mx-6'>
 								Sort by:
 							</div>
 							<div data-cy='catalogue-dropdown-filter'>

--- a/src/pages/ContributionPage.tsx
+++ b/src/pages/ContributionPage.tsx
@@ -47,17 +47,9 @@ const ContributionPage = () => {
 									{children}
 								</a>
 							),
-							img: ({ children, ...props }) => {
-								let rawUrl = props.src ?? ''
-
-								if (rawUrl.includes('github.com') && rawUrl.includes('/blob')) {
-									rawUrl = rawUrl
-										.replace('github.com', 'raw.githubusercontent.com')
-										.replace('/blob', '')
-								}
-
-								return <img className='' src={rawUrl} alt={props.alt} />
-							},
+							img: ({ children, ...props }) => (
+								<img src={props.src} alt={props.alt} />
+							),
 							p: ({ children }) => <p className='text-[#82838D]'>{children}</p>,
 							ul: ({ children }) => (
 								<ul className='list-disc  text-[#82838D]'>{children}</ul>

--- a/src/pages/ContributionPage.tsx
+++ b/src/pages/ContributionPage.tsx
@@ -77,8 +77,26 @@ const ContributionPage = () => {
 									{children}
 								</code>
 							),
-							tr: ({ children }) => (
-								<tr className='!bg-white text-[#82838D] '>{children}</tr>
+							th: ({ children, ...props }) => (
+								<th
+									className='!border-[#82838D] !bg-white text-[#82838D]'
+									{...props}
+								>
+									{children}
+								</th>
+							),
+							tr: ({ children, ...props }) => (
+								<tr
+									className='text-[#82838D] odd:!bg-white even:!bg-[#f6f6f6]'
+									{...props}
+								>
+									{children}
+								</tr>
+							),
+							td: ({ children, ...props }) => (
+								<td className='!border-[#82838D]' {...props}>
+									{children}
+								</td>
 							)
 						}}
 						remarkPlugins={[remarkGfm] as PluggableList}

--- a/src/pages/ContributionPage.tsx
+++ b/src/pages/ContributionPage.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-unstable-nested-components */
 /* eslint-disable react/jsx-props-no-spreading  */
+/* eslint-disable react/prop-types  */
 
 import { Skeleton } from 'antd'
 import 'github-markdown-css'
@@ -46,6 +47,17 @@ const ContributionPage = () => {
 									{children}
 								</a>
 							),
+							img: ({ children, ...props }) => {
+								let rawUrl = props.src ?? ''
+
+								if (rawUrl.includes('github.com') && rawUrl.includes('/blob')) {
+									rawUrl = rawUrl
+										.replace('github.com', 'raw.githubusercontent.com')
+										.replace('/blob', '')
+								}
+
+								return <img className='' src={rawUrl} alt={props.alt} />
+							},
 							p: ({ children }) => <p className='text-[#82838D]'>{children}</p>,
 							ul: ({ children }) => (
 								<ul className='list-disc  text-[#82838D]'>{children}</ul>

--- a/src/pages/ContributionPage.tsx
+++ b/src/pages/ContributionPage.tsx
@@ -27,7 +27,7 @@ const ContributionPage = () => {
 	return (
 		<div className='markdown-body flex justify-center border-t-[1px] bg-white p-12'>
 			{markdown ? (
-				<div className=' max-w-[850px] text-black'>
+				<div className='w-full max-w-[850px] text-black sm:w-auto'>
 					<ReactMarkdown
 						components={{
 							h1: ({ children }) => (

--- a/src/pages/ContributionPage.tsx
+++ b/src/pages/ContributionPage.tsx
@@ -62,8 +62,10 @@ const ContributionPage = () => {
 							ul: ({ children }) => (
 								<ul className='list-disc  text-[#82838D]'>{children}</ul>
 							),
-							ol: ({ children }) => (
-								<ol className='list-disc  text-[#82838D]'>{children}</ol>
+							ol: ({ children, ...props }) => (
+								<ol className='list-disc text-[#82838D]' {...props}>
+									{children}
+								</ol>
 							),
 							pre: ({ children }) => (
 								<pre className='!text-md  !bg-[#f6f6f6] font-normal text-[#24295C]'>


### PR DESCRIPTION
## Extra details

This PR fixes a bunch of errors related to bad margins, and phantom backgrounds appearing in mobile sized screens

## Changelog

- [x] adds styling to contribution page tables
- [x] add conditionally converts github images from relative path to absolute path
- [x] make header and footer responsive
- [x] make catalogue search page, contribution page, and catalogue item page responsive


## How to test

https://github.com/thinkingmachines/unicef-ai4d-research-bank/assets/122899250/b21e6fb9-1f15-4ea2-b904-424defba6439

1. Assert that the the header and footer are responsive
2. Assert that the catalogue search page is responsive
3. Assert that the catalogue item page is responsive
4. Assert that the contribution page is responsive
5. Assert that the tables in the contribution page render zebra striped color styling
