### PR TITLE
fix:Update deploy to avoid erroring out on no catalog item updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,12 +63,15 @@ jobs:
       - name: Update detail images
         run: cd public/assets && git add . && cd ../..
 
-      - name: Commit changes if there are any pending
+      - name: Setup git config
         run: |
           git config --global user.name 'CI:Butch Landingin'
           git config --global user.email 'butchtm@users.noreply.github.com'
-          git diff --cached > /dev/null 2>&1 && git commit -m "ci:Refresh catalog items, site-generated and assets"
-          git log origin/main..HEAD > /dev/null 2>&1 && git push
+
+      - name: Commit changes if there are any pending
+        run: |
+          git diff --cached > /dev/null 2>&1 && git commit -m "ci:Refresh catalog items, site-generated and assets" && git push && echo "Catalog items updated"
+          ! git diff --cached > /dev/null 2>&1 && echo "No catalog item updates"
 
       - name: Build project
         run: pnpm build

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,10 +5,10 @@ on:
     paths:
       - 'catalog/**.yml'
 
-  push:
-    branches: [main]
-    paths:
-      - 'catalog/**.yml'
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - 'catalog/**.yml'
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Fix deploy erroring out

- fix:  deploy gh action 
- chore: remove duplicate validation step on merge since deploy also validates
 
## Extra details

Add a echo if catalog items are updated or not so exit code for step to check for catalog changes (and committing them) is zero so that its not considered an error

