### PR TITLE
Update deploy action to avoid repeated triggering

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,11 @@ name: Deploy-GH-Pages
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'public/api/data/catalog.json'
+      - 'public/api/data/featured.json'
+      - 'public/assets/items/*.png'
+      - 'public/assets/multiregions/*.png'
 
   workflow_dispatch:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,15 +63,8 @@ jobs:
       - name: Update detail images
         run: cd public/assets && git add . && cd ../..
 
-      - name: Setup git config
-        run: |
-          git config --global user.name 'CI:Butch Landingin'
-          git config --global user.email 'butchtm@users.noreply.github.com'
-
       - name: Commit changes if there are any pending
-        run: |
-          git diff --cached > /dev/null 2>&1 && git commit -m "ci:Refresh catalog items, site-generated and assets" && git push && echo "Catalog items updated"
-          ! git diff --cached > /dev/null 2>&1 && echo "No catalog item updates"
+        run: ./scripts/commit-catalog.sh
 
       - name: Build project
         run: pnpm build

--- a/scripts/commit-catalog.sh
+++ b/scripts/commit-catalog.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/bash
 if [[ `git status --porcelain` ]]; then
-  # git config --global user.name 'CI:Butch Landingin'
-  # git config --global user.email 'butchtm@users.noreply.github.com'
-  git commit -m "chore: add commit-catalog script" 
+  git config --global user.name 'CI:Butch Landingin'
+  git config --global user.email 'butchtm@users.noreply.github.com'
+  git commit -m "ci: Update generated catalog items and detail images" 
   git push
   echo "Catalog items updated"
   true

--- a/scripts/commit-catalog.sh
+++ b/scripts/commit-catalog.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+if [[ `git status --porcelain` ]]; then
+  # git config --global user.name 'CI:Butch Landingin'
+  # git config --global user.email 'butchtm@users.noreply.github.com'
+  git commit -m "chore: add commit-catalog script" 
+  git push
+  echo "Catalog items updated"
+  true
+else
+  echo "No update of catalog items"
+fi
+echo "Done!"


### PR DESCRIPTION
## Update deploy action to avoid repeated triggering

- fix: update deploy action to avoid repeated triggering

## Extra details

- move logic to scripts/commit-catalog.sh
- add ignore paths for generated files
