### PR TITLE
fix: add intentallly public secret to gitleaksignore

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -880,3 +880,4 @@ ee2ca8b51346c1675158a09119c116adbd6eae3b:api/data/catalog.json:gcp-api-key:1
 d926d202f03339ff85abbe19245bd9b06aab0ba5:api/data/catalog.json:gcp-api-key:1
 05853f8f7e32f54e2ab8b266605132698610eae4:api/data/catalog.json:gcp-api-key:1
 f511c82cb4dd9aa49be3313310e3862fd5100865:notebooks/generate_map_images.ipynb:gcp-api-key:633
+f7db2c8c52a2328eeb1bed72769ac5b5e961faaf:public/api/data/catalog.json:gcp-api-key:1


### PR DESCRIPTION
# Description

Add intentially public secret to gitleaksignore to silence alerts.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
